### PR TITLE
fix: react-hook-formと早期リターンの順番を入れ替え

### DIFF
--- a/src/app/(protected)/admin/setting/password-form.tsx
+++ b/src/app/(protected)/admin/setting/password-form.tsx
@@ -19,13 +19,6 @@ type PasswordFormProps = {
 };
 
 export default function PasswordForm({ isOAuthUser }: PasswordFormProps) {
-  if (isOAuthUser) {
-    return (
-      <p className="text-sm text-muted-foreground">
-        Googleアカウントで認証しているためパスワードの設定はありません
-      </p>
-    );
-  }
   const {
     register,
     handleSubmit,
@@ -34,6 +27,14 @@ export default function PasswordForm({ isOAuthUser }: PasswordFormProps) {
     resolver: zodResolver(updatePasswordSchema),
     mode: 'onChange',
   });
+
+  if (isOAuthUser) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Googleアカウントで認証しているためパスワードの設定はありません
+      </p>
+    );
+  }
 
   const onSubmit = async (data: UpdatePasswordInput) => {
     try {


### PR DESCRIPTION
## 概要
PasswordFormでReactフックのルール違反を修正

## 問題
isOAuthUserによる早期リターンの後にuseFormを呼び出していたためESLintのreact-hooks/rules-of-hooksエラーが発生していた

## 原因
Reactのフックは条件分岐に関わらず常に同じ順序で呼ばれる必要がある早期リターンの後にフックを置くと、条件によって呼ばれない場合がありReactの状態管理が正しく機能しなくなる

## 対応
useFormの呼び出しをisOAuthUserの早期リターンより前に移動