### PR TITLE
chore: typecheckとcheckコマンドをscriptsに追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "typecheck": "tsc --noEmit",
+    "check": "npm run lint && npm run typecheck"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",


### PR DESCRIPTION
## 概要
コード品質チェック用にscriptsコマンドを追加

## 対応
- typecheck: tsc --noEmitでTypeScriptの型エラーを検出
- check: lintとtypecheckを一括実行するコマンドを追加

## 使う場面
- コミット前の最終確認として実行