### PR TITLE
fix: setting画面のプロフィール取得クエリにeqを追加

### DIFF
--- a/src/app/(protected)/admin/setting/page.tsx
+++ b/src/app/(protected)/admin/setting/page.tsx
@@ -20,6 +20,7 @@ export default async function SettingPage() {
   const { data: profile } = await supabase
     .from('profiles')
     .select('name, store_name, email, avatar_url')
+    .eq('id', user.id)
     .single();
 
   return (


### PR DESCRIPTION
## 概要
setting画面でプロフィール情報がnullになるバグを修正

## 原因
.eq('id', user.id)が抜けていたため

## 対応
.eq('id', user.id)を追加

Close #51 