### PR TITLE
fix: ログインページのスタッフタブのメッセージを修正

### DIFF
--- a/src/app/(auth)/login/login-form.tsx
+++ b/src/app/(auth)/login/login-form.tsx
@@ -204,8 +204,6 @@ export default function LoginForm() {
           <div className="rounded-lg bg-primary/10 p-4">
             <p className="text-xs text-muted-foreground text-center">
               スタッフはメールアドレスとパスワードでログインしてください
-              <br />
-              初回ログインの場合は招待メールをご確認ください
             </p>
           </div>
         </TabsContent>


### PR DESCRIPTION
## 概要
ログインページのスタッフタブのメッセージ内容を変更

## 問題箇所
スタッフは招待メールでログインする流れだった

## 変更箇所
招待メールは送らない実装なので文言を削除した