### PR TITLE
feat: スタッフのパスワード更新機能を実装

### DIFF
--- a/src/app/(protected)/admin/staff/actions.ts
+++ b/src/app/(protected)/admin/staff/actions.ts
@@ -6,6 +6,8 @@ import {
   AddStaffInput,
   addStaffSchema,
   EditStaffInput,
+  EditStaffPasswordInput,
+  editStaffPasswordSchema,
   editStaffSchema,
 } from '@/lib/validations/schemas';
 import { revalidatePath } from 'next/cache';
@@ -93,4 +95,26 @@ export async function editStaff(data: EditStaffInput, staffId: string) {
   if (error) throw new Error('スタッフの更新に失敗しました');
 
   revalidatePath('/admin/staff');
+}
+
+export async function editStaffPassword(
+  staffId: string,
+  data: EditStaffPasswordInput
+) {
+  const supabase = await createClient();
+  const supabaseAdmin = createAdminClient();
+
+  const validated = editStaffPasswordSchema.safeParse(data);
+  if (!validated.success) throw new Error('入力内容を確認してください');
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error('認証エラーが発生しました');
+
+  const { error } = await supabaseAdmin.auth.admin.updateUserById(staffId, {
+    password: data.password,
+  });
+
+  if (error) throw new Error('パスワードの更新に失敗しました');
 }

--- a/src/app/(protected)/admin/staff/components/staff-card-menu.tsx
+++ b/src/app/(protected)/admin/staff/components/staff-card-menu.tsx
@@ -27,7 +27,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Icons } from '@/components/icon/icons';
 import { Staff } from '../../../../../../types/staff';
-import { deleteStaff, editStaff } from '../actions';
+import { deleteStaff, editStaff, editStaffPassword } from '../actions';
 import { getErrorMessage } from '@/lib/utils/error-message';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
@@ -193,8 +193,9 @@ function EditPasswordDialog({
 
   const onSubmit = async (data: EditStaffPasswordInput) => {
     try {
-      await //Todo: パスワード変更処理
+      await editStaffPassword(staffId, data);
       toast.success('パスワードの更新に成功しました');
+      setIsEditPasswordOpen(false);
     } catch (error) {
       toast.error('パスワードの更新に失敗しました', {
         description: getErrorMessage(error),


### PR DESCRIPTION
## 概要
管理者がスタッフのパスワードを強制変更できる機能を実装

## 対応
- editStaffPassword Server Actionsを実装
- EditPasswordDialogのonSubmitに適用

## 技術的な判断
- 管理者による強制変更のためcreateAdminClientのupdateUserByIdを使用
- スタッフ自身の現在のパスワードは不要だが、タイプミス防止のため確認パスワードフィールドを残した