### PR TITLE
fix: setting画面のProfile型からnullを削除 closes #67

### DIFF
--- a/src/app/(protected)/admin/setting/page.tsx
+++ b/src/app/(protected)/admin/setting/page.tsx
@@ -23,6 +23,8 @@ export default async function SettingPage() {
     .eq('id', user.id)
     .single();
 
+  if (!profile) redirect('/login');
+
   return (
     <div className="mt-20 md:mt-0 max-w-7xl mx-auto w-full py-6 px-4 space-y-6">
       <BackPageLink href="/admin" label="ダッシュボードへ戻る" />
@@ -36,7 +38,7 @@ export default async function SettingPage() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <SettingForm profile={profile} userId={user.id} />
+            <SettingForm profile={profile}/>
           </CardContent>
         </Card>
 

--- a/src/app/(protected)/admin/setting/setting-form.tsx
+++ b/src/app/(protected)/admin/setting/setting-form.tsx
@@ -29,17 +29,16 @@ import { uploadAdminAvatar } from '@/lib/utils/upload';
 type Profile = Pick<
   Tables<'profiles'>,
   'name' | 'store_name' | 'email' | 'avatar_url'
-> | null;
+>;
 
 type SettingFormProps = {
   profile: Profile;
-  userId: string;
 };
 
 export default function SettingForm({ profile }: SettingFormProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [avatarUrl, setAvatarUrl] = useState<string | null>(
-    profile?.avatar_url ?? null
+    profile.avatar_url ?? null
   );
   const [isUploading, setIsUploading] = useState(false);
 
@@ -80,9 +79,9 @@ export default function SettingForm({ profile }: SettingFormProps) {
   } = useForm<UpdateProfileInput>({
     resolver: zodResolver(updateProfileSchema),
     defaultValues: {
-      name: profile?.name ?? '',
-      storeName: profile?.store_name ?? '',
-      email: profile?.email ?? '',
+      name: profile.name ?? '',
+      storeName: profile.store_name ?? '',
+      email: profile.email ?? '',
     },
   });
 


### PR DESCRIPTION
## 概要
setting画面のProfile型からnullを削除することによって
不要なオプショナルチェーニングを削除

## 対応
- setting/page.tsxに if (!profile) redirect('/login')を追加
- SettingFormのProfile型から | null を削除
- オプショナルチェーニングを削除
- SettingFormPropsの未使用のuserIdを削除

Closes #67