### PR TITLE
Refactor/supabase error handling

### DIFF
--- a/src/app/(auth)/resend-confirmation/reset-mail-form.tsx
+++ b/src/app/(auth)/resend-confirmation/reset-mail-form.tsx
@@ -25,7 +25,6 @@ export default function ResetMailForm() {
   });
   return (
     <form className="space-y-4" onSubmit={handleSubmit(resendConfirmation)}>
-      {/* メールアドレス */}
       <div className="space-y-2">
         <Label htmlFor="email">メールアドレス</Label>
         <Input
@@ -39,7 +38,6 @@ export default function ResetMailForm() {
         )}
       </div>
 
-      {/* 送信ボタン */}
       <Button
         type="submit"
         className="w-full"

--- a/src/app/(protected)/admin/page.tsx
+++ b/src/app/(protected)/admin/page.tsx
@@ -10,20 +10,21 @@ export default async function AdminPage() {
 
   const {
     data: { user },
+    error: authError,
   } = await supabase.auth.getUser();
-  if (!user) redirect('/login');
+  if (authError || !user) redirect('/login');
 
-  const { data: profile } = await supabase
+  const { data: profile, error: profileError } = await supabase
     .from('profiles')
     .select('name, store_name, role ,email, avatar_url')
     .eq('id', user.id)
     .single();
-  if (!profile) redirect('/login');
+  if (profileError || !profile) redirect('/login');
 
-  const { data: evaluationPeriods } = await supabase
+  const { data: evaluationPeriods, error: periodsError } = await supabase
     .from('evaluation_periods')
     .select('id, name');
-  if (!evaluationPeriods) return;
+  if (periodsError || !evaluationPeriods) return;
 
   return (
     <AdminContainer>

--- a/src/app/(protected)/admin/setting/actions.ts
+++ b/src/app/(protected)/admin/setting/actions.ts
@@ -48,7 +48,7 @@ export async function updatePassword(data: UpdatePasswordInput) {
   const validated = updatePasswordSchema.safeParse(data);
 
   if (!validated.success) {
-    throw { error: '入力内容を確認してください' };
+    throw new Error('入力内容を確認してください');
   }
 
   const { error: signInError } = await supabase.auth.signInWithPassword({
@@ -61,7 +61,7 @@ export async function updatePassword(data: UpdatePasswordInput) {
     password: validated.data.password,
   });
 
-  if (error) throw { error: 'パスワードの更新に失敗しました' };
+  if (error) throw new Error('パスワードの更新に失敗しました');
 
   return { success: true };
 }

--- a/src/app/(protected)/admin/setting/page.tsx
+++ b/src/app/(protected)/admin/setting/page.tsx
@@ -13,18 +13,19 @@ export default async function SettingPage() {
 
   const {
     data: { user },
+    error: authError,
   } = await supabase.auth.getUser();
 
-  if (!user) redirect('/login');
+  if (authError || !user) redirect('/login');
 
   const isOAuthUser = user?.app_metadata?.provider === 'google';
-  const { data: profile } = await supabase
+  const { data: profile, error: profileError } = await supabase
     .from('profiles')
     .select('name, store_name, email, avatar_url')
     .eq('id', user.id)
     .single();
 
-  if (!profile) redirect('/login');
+  if (profileError || !profile) redirect('/login');
 
   return (
     <AdminContainer>

--- a/src/app/(protected)/admin/setting/password-form.tsx
+++ b/src/app/(protected)/admin/setting/password-form.tsx
@@ -38,7 +38,11 @@ export default function PasswordForm({ isOAuthUser }: PasswordFormProps) {
 
   const onSubmit = async (data: UpdatePasswordInput) => {
     try {
-      await updatePassword(data);
+      const result = await updatePassword(data);
+      if (result?.error) {
+        toast.error(result.error);
+        return;
+      }
       toast.success('パスワードを更新しました');
     } catch (error) {
       toast.error('パスワードの更新に失敗しました', {

--- a/src/app/(protected)/admin/staff/[staffId]/evaluation/page.tsx
+++ b/src/app/(protected)/admin/staff/[staffId]/evaluation/page.tsx
@@ -34,14 +34,16 @@ export default async function EvaluationPage({
 
   const { orgId } = await requireAdmin(supabase);
 
-  const { data: staffProfile, error } = await supabase
+  const { data: staffProfile, error: staffProfileError } = await supabase
     .from('profiles')
     .select('name, store_name, role, email, avatar_url')
     .eq('organization_id', orgId)
     .eq('id', staffId)
     .single();
-  if (error) throw new Error('スタッフ情報の取得に失敗しました');
+  if (staffProfileError) throw new Error('スタッフ情報の取得に失敗しました');
 
+  //初回評価時はデータが存在しないためnullになるケースがある
+  //.single()はデータが存在しない場合もerrorを返すため意図的にerrorを無視している
   const { data: existingEvaluation } = (await supabase
     .from('evaluations')
     .select(

--- a/src/app/(protected)/admin/staff/[staffId]/page.tsx
+++ b/src/app/(protected)/admin/staff/[staffId]/page.tsx
@@ -19,12 +19,12 @@ export default async function StaffDetailPage({
 
   const { orgId } = await requireAdmin(supabase);
 
-  const { data: targetStaff } = await supabase
+  const { data: targetStaff, error: targetStaffError } = await supabase
     .from('profiles')
     .select('name, store_name, role, email, avatar_url')
     .eq('id', staffId)
     .single();
-  if (!targetStaff) redirect('/admin/staff');
+  if (targetStaffError || !targetStaff) redirect('/admin/staff');
 
   const { data: selectedPeriod, error } = await supabase
     .from('evaluation_periods')

--- a/src/app/(protected)/admin/staff/page.tsx
+++ b/src/app/(protected)/admin/staff/page.tsx
@@ -6,24 +6,29 @@ import { createClient } from '@/lib/supabase/server';
 import BackPageLink from '@/components/shared/back-page-link';
 import AdminContainer from '../components/admin-contaimer';
 import { requireAdmin } from '@/lib/utils/requireAdmin';
+import { redirect } from 'next/navigation';
 
 export default async function StaffManagementPage() {
   const supabase = await createClient();
 
   const { orgId } = await requireAdmin(supabase);
 
-  const { data: staffs } = await supabase
+  const { data: staffs, error: staffsError } = await supabase
     .from('profiles')
     .select('id, name, role, store_name, avatar_url, email')
     .eq('organization_id', orgId)
     .eq('role', 'staff');
 
-  const { data: selectedPeriod } = await supabase
+  if (staffsError) redirect('/admin');
+
+  const { data: selectedPeriod, error: periodError } = await supabase
     .from('evaluation_periods')
     .select('id')
     .eq('organization_id', orgId)
     .eq('is_current', true)
     .maybeSingle();
+
+  if (staffsError) redirect('/admin');
 
   return (
     <AdminContainer>

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -21,7 +21,11 @@ export async function GET(request: Request) {
 
   const {
     data: { user },
+    error: authError,
   } = await supabase.auth.getUser();
+
+  if (authError)
+    return NextResponse.redirect(new URL('/login?error=no_user', origin));
 
   if (!user) {
     console.error('No User found after OAuth');
@@ -34,7 +38,7 @@ export async function GET(request: Request) {
     .eq('id', user.id)
     .single();
 
-  if (profileError) {
+  if (profileError || !profile) {
     console.error('Profile fetch error:', profileError);
     return NextResponse.redirect(new URL('/login?error=profile', origin));
   }
@@ -42,9 +46,7 @@ export async function GET(request: Request) {
   //ログイン用OAuth
   if (intent === 'login') {
     const isValidAdmin =
-      profile !== null &&
-      profile.role === 'admin' &&
-      profile.is_setup_complete === true;
+      profile.role === 'admin' && profile.is_setup_complete === true;
 
     //未登録ユーザーはブロック
     if (!profile.is_setup_complete) {

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -43,19 +43,17 @@ export async function updateSession(request: NextRequest) {
 export async function getUserRole(
   supabase: SupabaseClient<Database>,
   userId: string
-): Promise<'admin' | 'staff' | null> {
+): Promise<'admin' | 'staff' | undefined> {
   const { data: profile, error } = await supabase
     .from('profiles')
     .select('role')
     .eq('id', userId)
     .single();
 
-  if (error) {
-    console.error('Get role error: ', error);
-    return null;
-  }
+  if (error) return undefined;
+  if (!profile) return undefined;
 
-  return profile?.role || null;
+  return profile.role as 'admin' | 'staff';
 }
 
 export async function isAdmin(

--- a/src/lib/utils/requireAdmin.ts
+++ b/src/lib/utils/requireAdmin.ts
@@ -6,8 +6,7 @@ export async function requireAdmin(supabase: SupabaseClient<Database>) {
     data: { user },
     error: authError,
   } = await supabase.auth.getUser();
-  if (!user) throw new Error('認証エラーが発生しました');
-  if (!user) throw new Error('認証エラーが発生しました');
+  if (authError || !user) throw new Error('認証エラーが発生しました');
 
   const { data: profile, error: profileError } = await supabase
     .from('profiles')

--- a/src/lib/utils/requireAdmin.ts
+++ b/src/lib/utils/requireAdmin.ts
@@ -4,15 +4,18 @@ import { Database } from '../../../types/supabase';
 export async function requireAdmin(supabase: SupabaseClient<Database>) {
   const {
     data: { user },
+    error: authError,
   } = await supabase.auth.getUser();
   if (!user) throw new Error('認証エラーが発生しました');
+  if (!user) throw new Error('認証エラーが発生しました');
 
-  const { data: profile } = await supabase
+  const { data: profile, error: profileError } = await supabase
     .from('profiles')
     .select('store_name, role, organization_id')
     .eq('id', user.id)
     .single();
 
+  if (profileError) throw new Error('プロフィールの取得に失敗しました');
   if (!profile || profile.role !== 'admin' || !profile.organization_id) {
     throw new Error('この操作を行う権限または、組織設定がありません');
   }

--- a/src/lib/utils/upload.ts
+++ b/src/lib/utils/upload.ts
@@ -10,7 +10,10 @@ export async function uploadStaffAvatar(formData: FormData, staffId: string) {
 
   const {
     data: { user },
+    error: authError,
   } = await supabase.auth.getUser();
+
+  if (authError) throw new Error('認証エラーが発生しました');
   if (!user) throw new Error('認証エラーが発生しました');
 
   const file = formData.get('avatar') as File;
@@ -52,7 +55,10 @@ export async function uploadAdminAvatar(formData: FormData) {
 
   const {
     data: { user },
+    error: authError,
   } = await supabase.auth.getUser();
+
+  if (authError) throw new Error('認証エラーが発生しました');
   if (!user) throw new Error('認証エラーが発生しました');
 
   const file = formData.get('avatar') as File;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -44,11 +44,14 @@ export async function middleware(request: NextRequest) {
   // /setupへのアクセス制御
   //追加情報入力後の/setupへアクセス制御
   if (pathname === '/setup' && user) {
-    const { data: profile } = await supabase
+    const { data: profile, error } = await supabase
       .from('profiles')
       .select('is_setup_complete')
       .eq('id', user.id)
       .single();
+
+    if (error) return supabaseResponse;
+    if (!profile) return supabaseResponse;
 
     if (profile?.is_setup_complete) {
       const role = await getUserRole(supabase, user.id);


### PR DESCRIPTION
## 概要
エラーハンドリングの統一

##対応
- ミドルウェアのSupabaseクエリにエラーハンドリングを追加
- requireAdminのSupabaseクエリにエラーハンドリングを追加
- uploadStaffAvatar, uploadAdminAvatarに認証クエリのエラーハンドリングを追加
- OAuthコールバックのSupabaseクエリにエラーハンドリングを追加
- /admin/page.tsxのSupabaseクエリにエラーハンドリングを追加
- /admin/setting/page.tsxのSupabaseクエリにエラーハンドリングを追加
- /admin/staff/page.tsxのSupabaseクエリにエラーハンドリングを追加
- /admin/staff/\[staffId\]/page.tsxのSupabaseクエリにエラーハンドリングを追加
-  /admin/staff/\[staffId\]/evaluation/page.tsx
- パスワード更新のエラーハンドリングを修正

 ## 設計判断

Supabaseの事情をアプリケーション層に持ち込まない理由
Supabaseが返すerrorやnullをアプリケーション境界で吸収し、アプリケーション内ではthrow new Errorやredirectやreturn undefinedで統一した
これによりFirebaseなど別のDBに切り替えた場合でもアプリケーション層のエラーハンドリングは変更不要になる。