### PR TITLE
Feat/staff evaluation display

### DIFF
--- a/src/app/(protected)/admin/staff/components/staff-card.tsx
+++ b/src/app/(protected)/admin/staff/components/staff-card.tsx
@@ -5,15 +5,26 @@ import Image from 'next/image';
 import StaffCardMenu from './staff-card-menu';
 import { Staff } from '../../../../../../types/staff';
 import { Tables } from '../../../../../../types/supabase';
+import { ExistingEvaluationForStaffCard } from '../../../../../../types/evaluations';
+import { calcEvaluation } from '@/lib/utils/evaluation-calc';
 
 type EvaluationPeriod = Pick<Tables<'evaluation_periods'>, 'id'> | null;
 
 type StaffCardProps = {
   staff: Staff;
   selectedPeriod: EvaluationPeriod;
+  staffEvaluation: ExistingEvaluationForStaffCard | undefined;
 };
 
-export default function StaffCard({ staff, selectedPeriod }: StaffCardProps) {
+export default function StaffCard({
+  staff,
+  selectedPeriod,
+  staffEvaluation,
+}: StaffCardProps) {
+  const evaluation = staffEvaluation
+    ? calcEvaluation(staffEvaluation.evaluation_sections)
+    : null;
+
   return (
     <Card className="relative">
       <CardContent className="pb-4">
@@ -44,20 +55,30 @@ export default function StaffCard({ staff, selectedPeriod }: StaffCardProps) {
           <p>役職 {staff.role}</p>
           <p>店舗名 {staff.store_name}</p>
         </div>
-        {/* 現在の評価はダミー */}
-        <div className="mt-3 pt-3 border-t space-y-2">
-          <p className="text-xs font-medium text-muted-foreground">
-            現在の評価
-          </p>
-          <div className="flex flex-wrap gap-2">
-            <span className="text-xs text-muted-foreground mt-1 bg-primary/10 rounded-xl p-2">
-              総合評価: B
-            </span>
-            <span className="text-xs text-muted-foreground mt-1 bg-primary/10 rounded-xl p-2">
-              総合達成率78%
+        {staffEvaluation && evaluation ? (
+          <div className="mt-3 pt-3 border-t space-y-2">
+            <p className="text-xs font-medium text-muted-foreground">
+              現在の評価
+            </p>
+            <div className="flex flex-wrap gap-2">
+              <span className="text-xs text-muted-foreground mt-1 bg-primary/10 rounded-xl p-2">
+                {`総合評価: ${evaluation.rank}`}
+              </span>
+              <span className="text-xs text-muted-foreground mt-1 bg-primary/10 rounded-xl p-2">
+                {`総合達成率: ${evaluation.rate}%`}
+              </span>
+            </div>
+          </div>
+        ) : (
+          <div className="mt-3 pt-3 border-t space-y-2">
+            <p className="text-xs font-medium text-muted-foreground">
+              現在の評価
+            </p>
+            <span className="text-xs text-muted-foreground mt-1 bg-red-100 rounded-xl p-2">
+              未評価
             </span>
           </div>
-        </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/app/(protected)/admin/staff/components/staff-card.tsx
+++ b/src/app/(protected)/admin/staff/components/staff-card.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { Icons } from '@/components/icon/icons';
 import { Card, CardContent } from '@/components/ui/card';
 import Image from 'next/image';

--- a/src/app/(protected)/admin/staff/components/staff-list.tsx
+++ b/src/app/(protected)/admin/staff/components/staff-list.tsx
@@ -5,15 +5,21 @@ import StaffCard from './staff-card';
 import StaffSearch from './staff-search';
 import { Staff } from '../../../../../../types/staff';
 import { Tables } from '../../../../../../types/supabase';
+import { ExistingEvaluationForStaffCard } from '../../../../../../types/evaluations';
 
 type EvaluationPeriod = Pick<Tables<'evaluation_periods'>, 'id'> | null;
 
 type StaffListProps = {
   staffs: Staff[];
   selectedPeriod: EvaluationPeriod;
+  existingEvaluations: ExistingEvaluationForStaffCard[];
 };
 
-export default function StaffList({ staffs, selectedPeriod }: StaffListProps) {
+export default function StaffList({
+  staffs,
+  selectedPeriod,
+  existingEvaluations,
+}: StaffListProps) {
   const [search, setSearch] = useState('');
 
   const filterdStaffs = staffs.filter((staff) => staff.name.includes(search));
@@ -32,13 +38,19 @@ export default function StaffList({ staffs, selectedPeriod }: StaffListProps) {
           </p>
         ) : (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-            {filterdStaffs.map((staff) => (
-              <StaffCard
-                key={staff.id}
-                staff={staff}
-                selectedPeriod={selectedPeriod}
-              />
-            ))}
+            {filterdStaffs.map((staff) => {
+              const staffEvaluation = existingEvaluations.find(
+                (s) => s.staff_id === staff.id
+              );
+              return (
+                <StaffCard
+                  key={staff.id}
+                  staff={staff}
+                  selectedPeriod={selectedPeriod}
+                  staffEvaluation={staffEvaluation}
+                />
+              );
+            })}
           </div>
         )}
       </div>

--- a/src/app/(protected)/admin/staff/page.tsx
+++ b/src/app/(protected)/admin/staff/page.tsx
@@ -65,7 +65,11 @@ export default async function StaffManagementPage() {
         </CardHeader>
 
         <CardContent className="space-y-6">
-          <StaffList staffs={staffs ?? []} selectedPeriod={selectedPeriod} />
+          <StaffList
+            staffs={staffs ?? []}
+            selectedPeriod={selectedPeriod}
+            existingEvaluations={existingEvaluations}
+          />
         </CardContent>
       </Card>
     </AdminContainer>

--- a/src/app/(protected)/admin/staff/page.tsx
+++ b/src/app/(protected)/admin/staff/page.tsx
@@ -30,6 +30,27 @@ export default async function StaffManagementPage() {
 
   if (staffsError) redirect('/admin');
 
+  const { data: existingEvaluations, error: exisgintError } = await supabase
+    .from('evaluations')
+    .select(
+      `
+      id,
+      staff_id,
+        evaluation_sections (
+          skill_score,
+            skill_max,
+            hospitality_score,
+            hospitality_max,
+            cleanliness_score,
+            cleanliness_max
+        )
+      `
+    )
+    .eq('organization_id', orgId)
+    .eq('status', 'completed');
+
+  if (exisgintError) throw new Error('評価データの取得に失敗しました');
+
   return (
     <AdminContainer>
       <BackPageLink href="/admin" label="ダッシュボードへ戻る" />

--- a/types/evaluations.ts
+++ b/types/evaluations.ts
@@ -38,3 +38,19 @@ export type ExistingEvaluation = Pick<
   Tables<'evaluations'>,
   'id' | 'status' | 'action_plan' | 'total_comment' | 'future_vision'
 > & { evaluation_sections: ExistingEvaluationSection[] };
+
+export type ExistingEvaluationForStaffCard = Pick<
+  Tables<'evaluations'>,
+  'id' | 'staff_id'
+> &
+  {
+    evaluation_sections: Pick<
+      ExistingEvaluationSection,
+      | 'skill_score'
+      | 'skill_max'
+      | 'hospitality_score'
+      | 'hospitality_max'
+      | 'cleanliness_score'
+      | 'cleanliness_max'
+    >[];
+  }


### PR DESCRIPTION
## 概要
スタッフ管理ページでスタッフカードに評価の出力を実装

## 対応
- organization_idとstatusがcompletedでフィルタリング
- staff_idを含めてスタッフカードとの紐づけに備える
- staff-list.tsx: existingEvaluationsからstaffIdで絞り込みStaffCardコンポーネントへ流し込み
- staff-card.tsx: staffEvaluationに対してundefinedのチェックをしフォールバックを記述
- staff-card.tsx: データを流し込み画面に表示

## staffEvaluationの型定義をExistingEvaluationForStaffCardとundefinedのユニオン型にした理由

staff-list.tsxでstaff.idに一致するデータを絞り込むが不一致だとundefinedがstaff-card.tsxへ渡る。
staffEvaluation型に対してオプショナルチェーニング演算子を記述するパターンも考えたが、未評価のスタッフは初回時には必ず存在するため明示的にundefinedを型として定義し、未評価時のフォールバック処理を明確にする方針にした。

