### PR TITLE
Security/add orgid validation

### DIFF
--- a/src/app/(protected)/admin/actions.ts
+++ b/src/app/(protected)/admin/actions.ts
@@ -15,14 +15,14 @@ export async function createEvaluationPeriod(
 ) {
   const supabase = await createClient();
 
-  const { profile } = await requireAdmin(supabase);
+  const { orgId } = await requireAdmin(supabase);
 
   const validated = createEvaluationPeriodSchema.safeParse(data);
   if (!validated.success) throw new Error('入力内容を確認してください');
 
   const { error } = await supabase.from('evaluation_periods').insert({
     name: validated.data.name,
-    organization_id: profile.organization_id!,
+    organization_id: orgId,
   });
   if (error) throw new Error('評価期間の作成に失敗しました');
 
@@ -32,11 +32,12 @@ export async function createEvaluationPeriod(
 export async function deleteEvaluationPeriod(evaluationId: string) {
   const supabase = await createClient();
 
-  await requireAdmin(supabase);
+  const { orgId } = await requireAdmin(supabase);
 
   const { error } = await supabase
     .from('evaluation_periods')
     .delete()
+    .eq('organization_id', orgId)
     .eq('id', evaluationId);
 
   if (error) throw new Error('評価期間の削除に失敗しました');
@@ -50,7 +51,7 @@ export async function editEvaluationPeriod(
 ) {
   const supabase = await createClient();
 
-  await requireAdmin(supabase);
+  const { orgId } = await requireAdmin(supabase);
 
   const validated = editEvaluationPeriodSchema.safeParse(data);
   if (!validated.success) throw new Error('入力内容を確認してください');
@@ -60,6 +61,7 @@ export async function editEvaluationPeriod(
     .update({
       name: validated.data.name,
     })
+    .eq('organization_id', orgId)
     .eq('id', evaluationPeriodId);
 
   if (error) throw new Error('評価期間の更新に失敗しました');

--- a/src/app/(protected)/admin/page.tsx
+++ b/src/app/(protected)/admin/page.tsx
@@ -1,29 +1,20 @@
 import { createClient } from '@/lib/supabase/server';
-import { redirect } from 'next/navigation';
 import ProfileCard from '@/components/shared/profile-card';
 import EvaluationPeriodList from './components/evaluation-period-list';
 import AdminContainer from './components/admin-contaimer';
 import EvaluationSection from './components/evaluation-section';
+import { requireAdmin } from '@/lib/utils/requireAdmin';
 
 export default async function AdminPage() {
   const supabase = await createClient();
 
-  const {
-    data: { user },
-    error: authError,
-  } = await supabase.auth.getUser();
-  if (authError || !user) redirect('/login');
-
-  const { data: profile, error: profileError } = await supabase
-    .from('profiles')
-    .select('name, store_name, role ,email, avatar_url')
-    .eq('id', user.id)
-    .single();
-  if (profileError || !profile) redirect('/login');
+  const { orgId, profile } = await requireAdmin(supabase);
 
   const { data: evaluationPeriods, error: periodsError } = await supabase
     .from('evaluation_periods')
-    .select('id, name');
+    .select('id, name')
+    .eq('organization_id', orgId);
+
   if (periodsError || !evaluationPeriods) return;
 
   return (

--- a/src/app/(protected)/admin/setting/actions.ts
+++ b/src/app/(protected)/admin/setting/actions.ts
@@ -12,7 +12,7 @@ import {
 export async function updateProfile(data: UpdateProfileInput) {
   const supabase = await createClient();
 
-  const { user } = await requireAdmin(supabase);
+  const { user, orgId } = await requireAdmin(supabase);
 
   const validated = updateProfileSchema.safeParse(data);
   if (!validated.success) {
@@ -33,6 +33,7 @@ export async function updateProfile(data: UpdateProfileInput) {
       store_name: validated.data.storeName,
       email: validated.data.email,
     })
+    .eq('organization_id', orgId)
     .eq('id', user.id);
 
   if (error) throw new Error('プロフィールの更新に失敗しました');

--- a/src/app/(protected)/admin/setting/page.tsx
+++ b/src/app/(protected)/admin/setting/page.tsx
@@ -1,5 +1,3 @@
-import { redirect } from 'next/navigation';
-
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Icons } from '@/components/icon/icons';
 import SettingForm from './setting-form';
@@ -7,25 +5,14 @@ import PasswordForm from './password-form';
 import { createClient } from '@/lib/supabase/server';
 import BackPageLink from '@/components/shared/back-page-link';
 import AdminContainer from '../components/admin-contaimer';
+import { requireAdmin } from '@/lib/utils/requireAdmin';
 
 export default async function SettingPage() {
   const supabase = await createClient();
 
-  const {
-    data: { user },
-    error: authError,
-  } = await supabase.auth.getUser();
-
-  if (authError || !user) redirect('/login');
+  const { user, profile } = await requireAdmin(supabase);
 
   const isOAuthUser = user?.app_metadata?.provider === 'google';
-  const { data: profile, error: profileError } = await supabase
-    .from('profiles')
-    .select('name, store_name, email, avatar_url')
-    .eq('id', user.id)
-    .single();
-
-  if (profileError || !profile) redirect('/login');
 
   return (
     <AdminContainer>

--- a/src/app/(protected)/admin/staff/[staffId]/page.tsx
+++ b/src/app/(protected)/admin/staff/[staffId]/page.tsx
@@ -23,6 +23,7 @@ export default async function StaffDetailPage({
     .from('profiles')
     .select('name, store_name, role, email, avatar_url')
     .eq('id', staffId)
+    .eq('organization_id', orgId)
     .single();
   if (targetStaffError || !targetStaff) redirect('/admin/staff');
 

--- a/src/app/(protected)/admin/staff/actions.ts
+++ b/src/app/(protected)/admin/staff/actions.ts
@@ -17,7 +17,7 @@ export async function addStaff(data: AddStaffInput) {
   const supabase = await createClient();
   const supabaseAdmin = createAdminClient();
 
-  const { profile: adminProfile } = await requireAdmin(supabase);
+  const { profile: adminProfile, orgId } = await requireAdmin(supabase);
 
   const validated = addStaffSchema.safeParse(data);
   if (!validated.success) throw new Error('入力内容を確認してください');
@@ -29,7 +29,7 @@ export async function addStaff(data: AddStaffInput) {
     user_metadata: {
       name: validated.data.name,
       role: 'staff',
-      organization_id: adminProfile.organization_id,
+      organization_id: orgId,
       store_name: adminProfile.store_name,
       is_setup_complete: true,
     },
@@ -44,7 +44,16 @@ export async function deleteStaff(staffId: string) {
   const supabase = await createClient();
   const supabaseAdmin = createAdminClient();
 
-  await requireAdmin(supabase);
+  const { orgId } = await requireAdmin(supabase);
+
+  const { data: staff, error: staffError } = await supabase
+    .from('profiles')
+    .select('id')
+    .eq('id', staffId)
+    .eq('organization_id', orgId)
+    .single();
+
+  if (staffError || !staff) throw new Error('スタッフが見つかりません');
 
   const { error } = await supabaseAdmin.auth.admin.deleteUser(staffId);
   if (error) throw new Error('スタッフの削除に失敗しました');
@@ -56,7 +65,7 @@ export async function editStaff(data: EditStaffInput, staffId: string) {
   const supabase = await createClient();
   const supabaseAdmin = createAdminClient();
 
-  await requireAdmin(supabase);
+  const { orgId } = await requireAdmin(supabase);
 
   const validated = editStaffSchema.safeParse(data);
   if (!validated.success) throw new Error('入力内容を確認してください');
@@ -73,6 +82,7 @@ export async function editStaff(data: EditStaffInput, staffId: string) {
       name: validated.data.name,
       email: validated.data.email,
     })
+    .eq('organization_id', orgId)
     .eq('id', staffId);
 
   if (error) throw new Error('スタッフの更新に失敗しました');
@@ -87,7 +97,16 @@ export async function editStaffPassword(
   const supabase = await createClient();
   const supabaseAdmin = createAdminClient();
 
-  await requireAdmin(supabase);
+  const { orgId } = await requireAdmin(supabase);
+
+  const { data: staff, error: staffError } = await supabase
+    .from('profiles')
+    .select('id')
+    .eq('id', staffId)
+    .eq('organization_id', orgId)
+    .single();
+
+  if (staffError || !staff) throw new Error('スタッフが見つかりません');
 
   const validated = editStaffPasswordSchema.safeParse(data);
   if (!validated.success) throw new Error('入力内容を確認してください');

--- a/src/app/(protected)/admin/staff/page.tsx
+++ b/src/app/(protected)/admin/staff/page.tsx
@@ -21,14 +21,14 @@ export default async function StaffManagementPage() {
 
   if (staffsError) redirect('/admin');
 
-  const { data: selectedPeriod } = await supabase
+  const { data: selectedPeriod, error: selectedPeriodError } = await supabase
     .from('evaluation_periods')
     .select('id')
     .eq('organization_id', orgId)
     .eq('is_current', true)
     .maybeSingle();
 
-  if (staffsError) redirect('/admin');
+  if (selectedPeriodError) redirect('/admin');
 
   const { data: existingEvaluations, error: exisgintError } = await supabase
     .from('evaluations')
@@ -68,7 +68,7 @@ export default async function StaffManagementPage() {
           <StaffList
             staffs={staffs ?? []}
             selectedPeriod={selectedPeriod}
-            existingEvaluations={existingEvaluations}
+            existingEvaluations={existingEvaluations ?? []}
           />
         </CardContent>
       </Card>

--- a/src/lib/utils/requireAdmin.ts
+++ b/src/lib/utils/requireAdmin.ts
@@ -10,7 +10,7 @@ export async function requireAdmin(supabase: SupabaseClient<Database>) {
 
   const { data: profile, error: profileError } = await supabase
     .from('profiles')
-    .select('store_name, role, organization_id')
+    .select('store_name, role, organization_id, email, avatar_url, name')
     .eq('id', user.id)
     .single();
 


### PR DESCRIPTION
## 概要
Server ActionsでorgIdでの組織の権限チェックを実行することによりセキュリティを強化した


## 対応
- /admin/page.tsx, actions.ts: 権限チェックを追加
- /admin/setting/page.tsx, actions.ts: 権限チェックを追加
- /admin/staff/actions.ts: 組織の権限チェックを追加
- /admin/staff/[staffId]/page.tsx, actions.ts: 権限チェックを追加

## 設計判断
**deleteStaff, editStaffPasswordに組織チェックを追加した理由**
supabaseAdmin.auth.adminはAdmin APIのためorgIdでの絞り込みができない。
そのため操作前にprofilesテーブルでstaffIdとorgIdの両方で検索し、
同じ組織のスタッフかどうかを確認してから操作するようにした。

Closes #82