### PR TITLE
Refactor/remove as cast

### DIFF
--- a/src/app/(auth)/login/login-form.tsx
+++ b/src/app/(auth)/login/login-form.tsx
@@ -33,21 +33,21 @@ export default function LoginForm() {
 
   useEffect(() => {
     const method = localStorage.getItem('lastLoginMethod');
-    const tab = localStorage.getItem('lastLoginTab') as LoginTabValue;
+    const tab = localStorage.getItem('lastLoginTab');
 
     setLastLoginMethod(method);
 
-    if (tab === 'admin' || tab === 'staff') {
-      setActiveTab(tab);
-    }
+    if (tab !== 'admin' && tab !== 'staff') return;
+
+    setActiveTab(tab);
   }, []);
 
   const handleTabChange = (value: string) => {
-    const newTab = value as LoginTabValue;
-    setActiveTab(newTab);
+    if (value !== 'admin' && value !== 'staff') return;
+    setActiveTab(value);
     reset();
 
-    localStorage.setItem('lastLoginTab', newTab);
+    localStorage.setItem('lastLoginTab', value);
   };
 
   return (

--- a/src/app/(protected)/admin/staff/[staffId]/evaluation/components/section-tab.tsx
+++ b/src/app/(protected)/admin/staff/[staffId]/evaluation/components/section-tab.tsx
@@ -32,7 +32,8 @@ export default function SectionTab({
   const stickyRef = useRef<HTMLDivElement>(null);
 
   const handleTabChange = (v: string) => {
-    setActiveTab(v as 'skill' | 'hospitality' | 'cleanliness');
+    if (v !== 'skill' && v !== 'hospitality' && v !== 'cleanliness') return;
+    setActiveTab(v);
 
     const offset = window.innerWidth >= 768 ? 0 : 80;
     if (stickyRef.current) {

--- a/src/app/(protected)/admin/staff/[staffId]/evaluation/utils.ts
+++ b/src/app/(protected)/admin/staff/[staffId]/evaluation/utils.ts
@@ -5,26 +5,53 @@ import {
   FormattedEvaluation,
 } from '../../../../../../../types/evaluations';
 
+const EMPTY_SECTION_DATA: SectionData = {
+  skill: {},
+  hospitality: {},
+  cleanliness: {},
+  good_points: [],
+  improvement_points: [],
+};
+
 //evaluation_itemsをcategoryごとに{item_name: score}の形に整形する
 export const formatCategoryScores = (items: EvaluationItem[]) =>
-  items.reduce((acc, cur) => {
-    if (!acc[cur.category]) acc[cur.category] = {};
-    acc[cur.category][cur.item_name] = cur.score ?? 0;
-    return acc;
-  }, {} as SectionData);
+  items.reduce<SectionData>(
+    (acc, cur) => {
+      if (!acc[cur.category]) acc[cur.category] = {};
+      acc[cur.category][cur.item_name] = cur.score ?? 0;
+      return acc;
+    },
+    {
+      ...EMPTY_SECTION_DATA,
+    }
+  );
 
 //既存評価データをEvaluationFormのdefaultValues形式に整形する
 export const formatEvaluationData = (
   existingEvaluation: ExistingEvaluation
 ) => {
-  const result = existingEvaluation.evaluation_sections.reduce((acc, cur) => {
-    acc[cur.section_type] = {
-      ...formatCategoryScores(cur.evaluation_items),
-      good_points: (cur.good_points ?? []) as string[],
-      improvement_points: (cur.improvement_points ?? []) as string[],
-    };
-    return acc;
-  }, {} as FormattedEvaluation);
+  const result =
+    existingEvaluation.evaluation_sections.reduce<FormattedEvaluation>(
+      (acc, cur) => {
+        acc[cur.section_type] = {
+          ...formatCategoryScores(cur.evaluation_items),
+          good_points: cur.good_points ?? [],
+          improvement_points: cur.improvement_points ?? [],
+        };
+        return acc;
+      },
+      {
+        basic: {
+          ...EMPTY_SECTION_DATA,
+        },
+        barista: {
+          ...EMPTY_SECTION_DATA,
+        },
+        cashier: {
+          ...EMPTY_SECTION_DATA,
+        },
+      }
+    );
 
   return result;
 };

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -51,9 +51,11 @@ export async function getUserRole(
     .single();
 
   if (error) return undefined;
-  if (!profile) return undefined;
 
-  return profile.role as 'admin' | 'staff';
+  const role = profile?.role;
+  if (role !== 'admin' && role !== 'staff') return undefined;
+
+  return role;
 }
 
 export async function isAdmin(

--- a/src/lib/utils/error-message.ts
+++ b/src/lib/utils/error-message.ts
@@ -5,8 +5,13 @@ export function getErrorMessage(error: unknown): string {
   }
 
   //SupabaseのAuthError
-  if (typeof error === 'object' && error !== null && 'message' in error) {
-    return translateErrorMessage(error.message as string);
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'message' in error &&
+    typeof error.message === 'string'
+  ) {
+    return translateErrorMessage(error.message);
   }
 
   return '予期しないエラーが発生しました';

--- a/src/lib/utils/requireAdmin.ts
+++ b/src/lib/utils/requireAdmin.ts
@@ -15,12 +15,14 @@ export async function requireAdmin(supabase: SupabaseClient<Database>) {
     .single();
 
   if (profileError) throw new Error('プロフィールの取得に失敗しました');
-  if (!profile || profile.role !== 'admin' || !profile.organization_id) {
+
+  const organizationId = profile?.organization_id;
+
+  if (!profile || profile.role !== 'admin' || !organizationId) {
     throw new Error('この操作を行う権限または、組織設定がありません');
   }
 
-  //organization_idはnullチェック済みのためstring型にアサーション
-  const orgId = profile.organization_id as string;
+  const orgId = organizationId;
 
   return { user, profile, orgId };
 }

--- a/src/lib/utils/upload.ts
+++ b/src/lib/utils/upload.ts
@@ -16,8 +16,8 @@ export async function uploadStaffAvatar(formData: FormData, staffId: string) {
   if (authError) throw new Error('認証エラーが発生しました');
   if (!user) throw new Error('認証エラーが発生しました');
 
-  const file = formData.get('avatar') as File;
-  if (!file) throw new Error('ファイルが選択されていません');
+  const file = formData.get('avatar');
+  if (!(file instanceof File)) throw new Error('ファイルが選択されていません');
 
   if (!AVATAR_ALLOWED_TYPES.includes(file.type)) {
     throw new Error('jpeg・png・webp形式の画像を選択してください');
@@ -61,8 +61,8 @@ export async function uploadAdminAvatar(formData: FormData) {
   if (authError) throw new Error('認証エラーが発生しました');
   if (!user) throw new Error('認証エラーが発生しました');
 
-  const file = formData.get('avatar') as File;
-  if (!file) throw new Error('ファイルが選択されていません');
+  const file = formData.get('avatar');
+  if (!(file instanceof File)) throw new Error('ファイルが選択されていません');
 
   if (!AVATAR_ALLOWED_TYPES.includes(file.type)) {
     throw new Error('jpeg・png・webp形式の画像を選択してください');

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -55,7 +55,8 @@ export async function middleware(request: NextRequest) {
 
     if (profile?.is_setup_complete) {
       const role = await getUserRole(supabase, user.id);
-      const redirectTo = role === 'admin' ? '/admin' : '/staff';
+      const redirectTo =
+        role === 'admin' ? '/admin' : role === 'staff' ? '/staff' : '/login';
       return NextResponse.redirect(new URL(redirectTo, request.url));
     }
   }
@@ -66,7 +67,8 @@ export async function middleware(request: NextRequest) {
 
   if (isAuthPath && user && isEmailConfirmed(user)) {
     const role = await getUserRole(supabase, user.id);
-    const redirectTo = role === 'admin' ? '/admin' : '/staff';
+    const redirectTo =
+      role === 'admin' ? '/admin' : role === 'staff' ? '/staff' : '/login';
     return NextResponse.redirect(new URL(redirectTo, request.url));
   }
 


### PR DESCRIPTION
## 概要
型エラーを黙らせるためだけのasキャストが存在する
根拠の無いasキャストを削除することによって、より堅牢で保守性の優れるコードにするようにした
根拠のあるas（DBのCHECK制約、null チェック済みなど）はコメントを残して許容する

## 対応

- reduce<SectionData>, reduce<FormattedEvaluation>でジェネリクスを使用
- requireAdminでorgIdのas string キャストを削除
- getUserRoleのasキャストをtype guardに変更しundefinedの処理を追加
- handleTabChange内でtype guardしsetActiveTabの引数のasキャストを削除
- login-form.tsxでtype guardをを使いasキャストを削除
- getErrorMessageでerror.messageをType Narrowingしas キャストを削除
- upload関数のas キャストをinstanceofによるType Narrowingに変更

## 設計判断
**asキャストを削除した理由**
asキャストはコンパイル時にTSを騙すだけで実行時の型安全性は保証されない。
Type Narrowingやジェネリクスを使うことでTSが自分で型を推論できるようにした。
これにより将来的に型が変わった場合もコンパイルエラーで検知できるようになる。

Closes #105