### PR TITLE
Fix/staff evaluation section

### DIFF
--- a/src/app/(protected)/admin/staff/[staffId]/components/staff-evaluation-section.tsx
+++ b/src/app/(protected)/admin/staff/[staffId]/components/staff-evaluation-section.tsx
@@ -11,7 +11,10 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import OverallEvaluation from './overall-evaluation';
 import { useState } from 'react';
-import { getEvaluationItemsBySection } from '@/lib/utils/evaluation-utils';
+import {
+  getEvaluationItemsBySection,
+  isSectionType,
+} from '@/lib/utils/evaluation-utils';
 import SectionEvaluationContent from './section-evaluation-content';
 
 type EvaluationPeriod = Pick<Tables<'evaluation_periods'>, 'id' | 'name'>;
@@ -29,10 +32,13 @@ export default function StaffEvaluationSection({
 }: StaffEvaluationSectionProps) {
   const [activeTab, setActiveTab] = useState<SectionType>('basic');
   const handleTabChange = (v: string) => {
-    if (v !== 'basic' && v !== 'barista' && v !== 'cashier') return;
+    if (v === 'all') return;
 
-    setActiveTab(v);
+    if (isSectionType(v)) {
+      setActiveTab(v);
+    }
   };
+
   const targetEvaluationItems = getEvaluationItemsBySection(
     targetEvaluation.evaluation_sections,
     activeTab

--- a/src/components/evaluation/section-tab.tsx
+++ b/src/components/evaluation/section-tab.tsx
@@ -14,7 +14,10 @@ import {
 } from '../../../types/evaluations';
 import { Label } from '../ui/label';
 import { useState } from 'react';
-import { filterEvaluationItemsByCategory } from '@/lib/utils/evaluation-utils';
+import {
+  filterEvaluationItemsByCategory,
+  isCategoryType,
+} from '@/lib/utils/evaluation-utils';
 
 type SectionTabProps = {
   items: {
@@ -52,10 +55,11 @@ export default function SectionTab({
   );
 
   const handleTabChange = (v: string) => {
-    if (v !== 'skill' && v !== 'hospitality' && v !== 'cleanliness') return;
-
-    setActiveTab(v);
+    if (isCategoryType(v)) {
+      setActiveTab(v);
+    }
   };
+
   return (
     <div>
       <Label>

--- a/src/lib/utils/evaluation-utils.ts
+++ b/src/lib/utils/evaluation-utils.ts
@@ -39,3 +39,7 @@ export const filterEvaluationItemsByCategory = (
 ) => {
   return evaluationItems.filter((items) => items.category === section);
 };
+
+export const isSectionType = (v: string): v is SectionType => {
+  return ['basic', 'barista', 'cashier'].includes(v);
+};

--- a/src/lib/utils/evaluation-utils.ts
+++ b/src/lib/utils/evaluation-utils.ts
@@ -43,3 +43,7 @@ export const filterEvaluationItemsByCategory = (
 export const isSectionType = (v: string): v is SectionType => {
   return ['basic', 'barista', 'cashier'].includes(v);
 };
+
+export const isCategoryType = (v: string): v is Category => {
+  return ['skill', 'hospitality', 'cleanlienss'].includes(v);
+};

--- a/src/lib/utils/evaluation-utils.ts
+++ b/src/lib/utils/evaluation-utils.ts
@@ -45,5 +45,5 @@ export const isSectionType = (v: string): v is SectionType => {
 };
 
 export const isCategoryType = (v: string): v is Category => {
-  return ['skill', 'hospitality', 'cleanlienss'].includes(v);
+  return ['skill', 'hospitality', 'cleanliness'].includes(v);
 };


### PR DESCRIPTION
## 概要
staff-evaluation-section.tsxとsectionTab.tsxのhandleTabChange関数のリファクタリングを行った。

## 問題点
- staff-evaluation-section.tsx: 
handleTabChange関数にてif (v !== 'basic' && v !== 'barista' && v !== 'cashier') return;の記述で暗黙的にallを除外しているが非常に分かりにくいので修正が必要。
- sectionTab.tsx: staff-evaluation-section.tsx同様の記述をしているがこちらはallは存在しない。
しかし直感的でないため修正が必要。

## 対応
- staff-evaluation-section.tsx
  - v === 'all' の場合に明示的に早期returnを追加
  - isSectionType Type Guardを作成しsetActiveTabへの型を保証
- section-tab.tsx
  - isCategoryType Type Guardを作成しsetActiveTabへの型を保証

## 設計理由
staff-evaluation-sectionのhandleTabChangeで'all'に対しての処理を記述しているので他者からみても分かりやすくなっている。
また、TypeGuardをisSectionType/isCategoryTypeで実行しているのでasキャスト不要なため保守性も保つことが出来た。
TypeGuardはevaluation-utils.tsに集約
