### PR TITLE
refactor: evaluation-page-add-type-guard

### DIFF
--- a/src/app/(protected)/admin/staff/[staffId]/evaluation/components/section-tab.tsx
+++ b/src/app/(protected)/admin/staff/[staffId]/evaluation/components/section-tab.tsx
@@ -8,6 +8,7 @@ import { useRef, useState } from 'react';
 import FeedbackComments from './feedback-comments';
 import { UseFormSetValue, UseFormWatch } from 'react-hook-form';
 import { EvaluationInput } from '@/lib/validations/schemas';
+import { isCategoryType } from '@/lib/utils/evaluation-utils';
 
 type SectionTablProps = {
   skillItems: EvaluationItemConstant[];
@@ -32,8 +33,9 @@ export default function SectionTab({
   const stickyRef = useRef<HTMLDivElement>(null);
 
   const handleTabChange = (v: string) => {
-    if (v !== 'skill' && v !== 'hospitality' && v !== 'cleanliness') return;
-    setActiveTab(v);
+    if (isCategoryType(v)) {
+      setActiveTab(v);
+    }
 
     const offset = window.innerWidth >= 768 ? 0 : 80;
     if (stickyRef.current) {


### PR DESCRIPTION
## 概要
評価ページでタブの値をuseStateで管理している箇所がある。
handleTabChangeの引数にはstring型が渡ってくるのでsetStateに渡す値の型を絞るためにif文で記述しているが専用の関数を使って可読性を高めた。

## 問題点
section-tab.tsx:
if (v !== 'skill' && v !== 'hospitality' && v !== 'cleanliness') return;
上記の記述をしているが可読性が悪いため修正する。

## 対応
isCategoryType関数を使って型を絞った。

## 設計理由
handleTabChangeに渡ってくる文字列はstringである。
isCategoryType関数に渡すと'skill', 'hospitality', 'cleanliness'の文字列しか返って来ないため型の保証が担保され、可読性も良くなる。