### PR TITLE
feat: 現在選択中の評価期間を管理者ダッシュボードで表示

### DIFF
--- a/src/app/(protected)/admin/components/evaluation-section.tsx
+++ b/src/app/(protected)/admin/components/evaluation-section.tsx
@@ -3,7 +3,10 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import EvaluationPeriodSelect from './evaluation-period-select';
 import { Tables } from '../../../../../types/supabase';
 
-type EvaluationPeriod = Pick<Tables<'evaluation_periods'>, 'id' | 'name'>;
+type EvaluationPeriod = Pick<
+  Tables<'evaluation_periods'>,
+  'id' | 'name' | 'is_current'
+>;
 
 type EvaluationSectionProps = {
   evaluationPeriods: EvaluationPeriod[];
@@ -14,6 +17,10 @@ export default function EvaluationSection({
   evaluationPeriods,
   label,
 }: EvaluationSectionProps) {
+  const currentEvaluationPeriod = evaluationPeriods.find(
+    (period) => period.is_current
+  );
+
   return (
     <Card>
       <CardHeader>
@@ -23,6 +30,20 @@ export default function EvaluationSection({
         </CardTitle>
       </CardHeader>
       <CardContent>
+        <div className="space-y-2 mb-2">
+          <p className="text-sm text-muted-foreground">
+            現在の期間:
+            {currentEvaluationPeriod ? (
+              <span className="font-medium text-foreground">
+                {currentEvaluationPeriod.name}
+              </span>
+            ) : (
+              <span className="font-medium text-foreground">
+                評価期間を作成して設定してください
+              </span>
+            )}
+          </p>
+        </div>
         <EvaluationPeriodSelect evaluationPeriods={evaluationPeriods} />
       </CardContent>
     </Card>

--- a/src/app/(protected)/admin/page.tsx
+++ b/src/app/(protected)/admin/page.tsx
@@ -12,7 +12,7 @@ export default async function AdminPage() {
 
   const { data: evaluationPeriods, error: periodsError } = await supabase
     .from('evaluation_periods')
-    .select('id, name')
+    .select('id, name, is_current')
     .eq('organization_id', orgId);
 
   if (periodsError || !evaluationPeriods) return;
@@ -25,7 +25,10 @@ export default async function AdminPage() {
         </div>
         <EvaluationPeriodList evaluationPeriods={evaluationPeriods} />
       </div>
-      <EvaluationSection evaluationPeriods={evaluationPeriods} label="評価" />
+      <EvaluationSection
+        evaluationPeriods={evaluationPeriods}
+        label="評価"
+      />
     </AdminContainer>
   );
 }


### PR DESCRIPTION
## 概要
管理者ダッシュボードページに評価期間を選択するselectがある。
現在選択中を表示するUIがなかったので実装した。

## 問題点
ダッシュボードで現在選択している評価期間の表示がないためUXが低下する。

## 対応
- evaluationPeriods取得のクエリにis_currentを追加
- evaluationPeriodsからfindメソッドでis_currentがtrueのperiodを絞り込む
- Selectの上部に表示

## 設計理由
page.tsxでevaluationPeriodsを取得するクエリにis_currentカラムを追加した。
is_currentに絞り個別で取得する方法も検討したがクエリが２回になるため断念した。
evaluation-section.tsxでcurrentEvaluationPeriodを取得するためevaluationPeriodsに対してfindメソッドで絞り込みをした。
初回時はundefinedが返ってくるが、jsxで分岐させているのでundefinedが渡っても問題はない。

Closes #86