### PR TITLE
Feat/admin dashboard page

### DIFF
--- a/src/app/(protected)/admin/components/evaluation-section.tsx
+++ b/src/app/(protected)/admin/components/evaluation-section.tsx
@@ -15,17 +15,15 @@ type EvaluationPeriod = Pick<
 
 type EvaluationSectionProps = {
   evaluationPeriods: EvaluationPeriod[];
+  currentEvaluationPeriod?: EvaluationPeriod;
   label: string;
 };
 
 export default function EvaluationSection({
   evaluationPeriods,
+  currentEvaluationPeriod,
   label,
 }: EvaluationSectionProps) {
-  const currentEvaluationPeriod = evaluationPeriods.find(
-    (period) => period.is_current
-  );
-
   return (
     <Card>
       <CardHeader>

--- a/src/app/(protected)/admin/components/evaluation-section.tsx
+++ b/src/app/(protected)/admin/components/evaluation-section.tsx
@@ -6,6 +6,7 @@ import SectionEvaluationLayout from '@/components/evaluation/section-evaluation-
 import SectionEvaluationDetail from '@/components/evaluation/section-evaluation-detail';
 import { Label } from '@/components/ui/label';
 import ProgressBar from '@/components/evaluation/progress-bar';
+import { Button } from '@/components/ui/button';
 
 type EvaluationPeriod = Pick<
   Tables<'evaluation_periods'>,
@@ -91,6 +92,28 @@ export default function EvaluationSection({
                 9人
               </span>
             </div>
+          </div>
+          <Label>
+            <span className="size-2 bg-primary rounded-full" />
+            未評価スタッフ一覧
+          </Label>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            <Card>
+              <CardContent className="pb-4">
+                <div className="flex flex-col justify-center gap-y-5">
+                  <div className="flex items-center justify-center gap-2">
+                    <div className="w-10 h-10 rounded-full bg-card flex items-center justify-center overflow-hidden shrink-0">
+                      <Icons.UserCircle className="h-10 w-10 text-muted-foreground" />
+                    </div>
+                    <span className="font-medium text-sm">山田太郎</span>
+                  </div>
+                  <Button size="sm" variant="ghost" className="text-primary">
+                    <span>評価する</span>
+                    <Icons.ArrowBigRight className="w-5 h-5" />
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
           </div>
         </div>
       </CardContent>

--- a/src/app/(protected)/admin/components/evaluation-section.tsx
+++ b/src/app/(protected)/admin/components/evaluation-section.tsx
@@ -11,6 +11,8 @@ import { TotalEvaluations } from '../../../../../types/evaluations';
 import { calcEvaluation } from '@/lib/utils/evaluation-calc';
 import { formatCategoryRates } from '@/lib/utils/evaluation-format';
 import { Staff } from '../../../../../types/staff';
+import Image from 'next/image';
+import Link from 'next/link';
 
 type EvaluationPeriod = Pick<
   Tables<'evaluation_periods'>,
@@ -44,6 +46,10 @@ export default function EvaluationSection({
   const progressRate =
     totalStaffs > 0 ? Math.round((evaluatedStaffs / totalStaffs) * 100) : 0;
   const unevaluatedStaffs = totalStaffs - evaluatedStaffs;
+  const unevaluatedStaffLists = staffLists.filter(
+    (staff) =>
+      !totalEvaluations.some((evaluation) => evaluation.staff_id === staff.id)
+  );
   return (
     <Card>
       <CardHeader>
@@ -112,22 +118,43 @@ export default function EvaluationSection({
             未評価スタッフ一覧
           </Label>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-            <Card>
-              <CardContent className="pb-4">
-                <div className="flex flex-col justify-center gap-y-5">
-                  <div className="flex items-center justify-center gap-2">
-                    <div className="w-10 h-10 rounded-full bg-card flex items-center justify-center overflow-hidden shrink-0">
-                      <Icons.UserCircle className="h-10 w-10 text-muted-foreground" />
+            {unevaluatedStaffLists.map((staff) => (
+              <Card key={staff.id}>
+                <CardContent className="pb-4">
+                  <div className="flex flex-col justify-center gap-y-5">
+                    <div className="flex items-center justify-center gap-2">
+                      <div className="w-10 h-10 rounded-full bg-card flex items-center justify-center overflow-hidden shrink-0">
+                        {staff.avatar_url ? (
+                          <Image
+                            src={staff.avatar_url}
+                            alt={staff.name}
+                            width={40}
+                            height={40}
+                            className="object-cover"
+                          />
+                        ) : (
+                          <Icons.UserCircle className="h-10 w-10 text-muted-foreground" />
+                        )}
+                      </div>
+                      <span className="font-medium text-sm">{staff.name}</span>
                     </div>
-                    <span className="font-medium text-sm">山田太郎</span>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="text-primary"
+                      asChild
+                    >
+                      <Link
+                        href={`/admin/staff/${staff.id}/evaluation?periodId=${currentEvaluationPeriod?.id}`}
+                      >
+                        評価する
+                        <Icons.ArrowBigRight className="w-5 h-5" />
+                      </Link>
+                    </Button>
                   </div>
-                  <Button size="sm" variant="ghost" className="text-primary">
-                    <span>評価する</span>
-                    <Icons.ArrowBigRight className="w-5 h-5" />
-                  </Button>
-                </div>
-              </CardContent>
-            </Card>
+                </CardContent>
+              </Card>
+            ))}
           </div>
         </div>
       </CardContent>

--- a/src/app/(protected)/admin/components/evaluation-section.tsx
+++ b/src/app/(protected)/admin/components/evaluation-section.tsx
@@ -43,6 +43,7 @@ export default function EvaluationSection({
   const evaluatedStaffs = totalEvaluations.length;
   const progressRate =
     totalStaffs > 0 ? Math.round((evaluatedStaffs / totalStaffs) * 100) : 0;
+  const unevaluatedStaffs = totalStaffs - evaluatedStaffs;
   return (
     <Card>
       <CardHeader>
@@ -93,7 +94,7 @@ export default function EvaluationSection({
                 完了
               </span>
               <span className="text-2xl sm:text-3xl text-muted-foreground font-bold">
-                21人
+                {evaluatedStaffs}
               </span>
             </div>
             <div className="flex flex-col aspect-square w-full max-w-45 items-center justify-center gap-1 border rounded-xl p-5">
@@ -102,7 +103,7 @@ export default function EvaluationSection({
                 未完了
               </span>
               <span className="text-2xl sm:text-3xl text-muted-foreground font-bold">
-                9人
+                {unevaluatedStaffs}
               </span>
             </div>
           </div>

--- a/src/app/(protected)/admin/components/evaluation-section.tsx
+++ b/src/app/(protected)/admin/components/evaluation-section.tsx
@@ -33,19 +33,21 @@ export default function EvaluationSection({
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-10">
-        <div className="flex flex-col gap-1">
-          <Label>
-            <Icons.CalendarDays className="w-5 h-5" />
-            現在の評価期間
-          </Label>
+        <div className="flex flex-col-reverse gap-y-8 sm:flex-row sm:justify-between">
+          <div className="flex flex-col gap-1">
+            <Label>
+              <Icons.CalendarDays className="w-5 h-5" />
+              現在の評価期間
+            </Label>
 
-          <p className="text-sm text-muted-foreground">
-            {currentEvaluationPeriod
-              ? currentEvaluationPeriod.name
-              : '評価期間を作成して設定してください'}
-          </p>
+            <p className="text-sm text-muted-foreground">
+              {currentEvaluationPeriod
+                ? currentEvaluationPeriod.name
+                : '評価期間を作成して設定してください'}
+            </p>
+          </div>
+          <EvaluationPeriodSelect evaluationPeriods={evaluationPeriods} />
         </div>
-        <EvaluationPeriodSelect evaluationPeriods={evaluationPeriods} />
         <Label>
           <span className="size-2 bg-primary rounded-full" />
           店舗全体評価

--- a/src/app/(protected)/admin/components/evaluation-section.tsx
+++ b/src/app/(protected)/admin/components/evaluation-section.tsx
@@ -27,6 +27,11 @@ type EvaluationSectionProps = {
   label: string;
 };
 
+type UnevaluatedStaffCardProps = {
+  staff: Staff;
+  periodId?: string;
+};
+
 export default function EvaluationSection({
   evaluationPeriods,
   currentEvaluationPeriod,
@@ -119,43 +124,48 @@ export default function EvaluationSection({
           </Label>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
             {unevaluatedStaffLists.map((staff) => (
-              <Card key={staff.id}>
-                <CardContent className="pb-4">
-                  <div className="flex flex-col justify-center gap-y-5">
-                    <div className="flex items-center justify-center gap-2">
-                      <div className="w-10 h-10 rounded-full bg-card flex items-center justify-center overflow-hidden shrink-0">
-                        {staff.avatar_url ? (
-                          <Image
-                            src={staff.avatar_url}
-                            alt={staff.name}
-                            width={40}
-                            height={40}
-                            className="object-cover"
-                          />
-                        ) : (
-                          <Icons.UserCircle className="h-10 w-10 text-muted-foreground" />
-                        )}
-                      </div>
-                      <span className="font-medium text-sm">{staff.name}</span>
-                    </div>
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      className="text-primary"
-                      asChild
-                    >
-                      <Link
-                        href={`/admin/staff/${staff.id}/evaluation?periodId=${currentEvaluationPeriod?.id}`}
-                      >
-                        評価する
-                        <Icons.ArrowBigRight className="w-5 h-5" />
-                      </Link>
-                    </Button>
-                  </div>
-                </CardContent>
-              </Card>
+              <UnevaluatedStaffCard
+                key={staff.id}
+                staff={staff}
+                periodId={currentEvaluationPeriod?.id}
+              />
             ))}
           </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function UnevaluatedStaffCard({ staff, periodId }: UnevaluatedStaffCardProps) {
+  return (
+    <Card>
+      <CardContent className="pb-4">
+        <div className="flex flex-col justify-center gap-y-5">
+          <div className="flex items-center justify-center gap-2">
+            <div className="w-10 h-10 rounded-full bg-card flex items-center justify-center overflow-hidden shrink-0">
+              {staff.avatar_url ? (
+                <Image
+                  src={staff.avatar_url}
+                  alt={staff.name}
+                  width={40}
+                  height={40}
+                  className="object-cover"
+                />
+              ) : (
+                <Icons.UserCircle className="h-10 w-10 text-muted-foreground" />
+              )}
+            </div>
+            <span className="font-medium text-sm">{staff.name}</span>
+          </div>
+          <Button size="sm" variant="ghost" className="text-primary" asChild>
+            <Link
+              href={`/admin/staff/${staff.id}/evaluation?periodId=${periodId}`}
+            >
+              評価する
+              <Icons.ArrowBigRight className="w-5 h-5" />
+            </Link>
+          </Button>
         </div>
       </CardContent>
     </Card>

--- a/src/app/(protected)/admin/components/evaluation-section.tsx
+++ b/src/app/(protected)/admin/components/evaluation-section.tsx
@@ -72,6 +72,26 @@ export default function EvaluationSection({
             sectionRates={[{ label: '進捗率', rate: 100 }]}
             label="評価進捗"
           />
+          <div className="flex gap-10 justify-around">
+            <div className="flex flex-col aspect-square w-full max-w-45 items-center justify-center gap-1 border rounded-xl p-5">
+              <span className="flex gap-1 items-center text-sm sm:text-lg text-green-400">
+                <Icons.Check className="w-5 h-5" />
+                完了
+              </span>
+              <span className="text-2xl sm:text-3xl text-muted-foreground font-bold">
+                21人
+              </span>
+            </div>
+            <div className="flex flex-col aspect-square w-full max-w-45 items-center justify-center gap-1 border rounded-xl p-5">
+              <span className="flex gap-1 items-center text-sm sm:text-lg text-gray-400">
+                <Icons.Users className="w-5 h-5" />
+                未完了
+              </span>
+              <span className="text-2xl sm:text-3xl text-muted-foreground font-bold">
+                9人
+              </span>
+            </div>
+          </div>
         </div>
       </CardContent>
     </Card>

--- a/src/app/(protected)/admin/components/evaluation-section.tsx
+++ b/src/app/(protected)/admin/components/evaluation-section.tsx
@@ -21,8 +21,6 @@ import {
   PaginationContent,
   PaginationItem,
   PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
 } from '@/components/ui/pagination';
 
 type EvaluationPeriod = Pick<
@@ -67,7 +65,7 @@ export default function EvaluationSection({
       !totalEvaluations.some((evaluation) => evaluation.staff_id === staff.id)
   );
   const [currentPage, setCurrentPage] = useState(1);
-  const pageSize = 4;
+  const pageSize = 6;
   const startIndex = (currentPage - 1) * pageSize;
   const currentItems = unevaluatedStaffLists.slice(
     startIndex,
@@ -154,9 +152,13 @@ export default function EvaluationSection({
           <Pagination>
             <PaginationContent>
               <PaginationItem>
-                <PaginationPrevious
+                <button
                   onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
-                />
+                  disabled={currentPage === 1}
+                  className="disabled:opacity-50"
+                >
+                  <Icons.ChevronLeft className="w-4 h-4" />
+                </button>
               </PaginationItem>
               {[...Array(totalPage)].map((_, i) => (
                 <PaginationItem key={i}>
@@ -169,11 +171,15 @@ export default function EvaluationSection({
                 </PaginationItem>
               ))}
               <PaginationItem>
-                <PaginationNext
+                <button
                   onClick={() =>
                     setCurrentPage((p) => Math.min(totalPage, p + 1))
                   }
-                />
+                  disabled={currentPage === totalPage}
+                  className="disabled:opacity-50"
+                >
+                  <Icons.ChevronRight className="w-4 h-4" />
+                </button>
               </PaginationItem>
             </PaginationContent>
           </Pagination>

--- a/src/app/(protected)/admin/components/evaluation-section.tsx
+++ b/src/app/(protected)/admin/components/evaluation-section.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/button';
 import { TotalEvaluations } from '../../../../../types/evaluations';
 import { calcEvaluation } from '@/lib/utils/evaluation-calc';
 import { formatCategoryRates } from '@/lib/utils/evaluation-format';
+import { Staff } from '../../../../../types/staff';
 
 type EvaluationPeriod = Pick<
   Tables<'evaluation_periods'>,
@@ -20,6 +21,7 @@ type EvaluationSectionProps = {
   evaluationPeriods: EvaluationPeriod[];
   totalEvaluations: TotalEvaluations[];
   currentEvaluationPeriod?: EvaluationPeriod;
+  staffLists: Staff[];
   label: string;
 };
 
@@ -27,6 +29,7 @@ export default function EvaluationSection({
   evaluationPeriods,
   currentEvaluationPeriod,
   totalEvaluations,
+  staffLists,
   label,
 }: EvaluationSectionProps) {
   const allSections = totalEvaluations.flatMap((v) => v.evaluation_sections);
@@ -36,6 +39,10 @@ export default function EvaluationSection({
     totalEvaluation.hospitalityRate,
     totalEvaluation.cleanlinessRate
   );
+  const totalStaffs = staffLists.length;
+  const evaluatedStaffs = totalEvaluations.length;
+  const progressRate =
+    totalStaffs > 0 ? Math.round((evaluatedStaffs / totalStaffs) * 100) : 0;
   return (
     <Card>
       <CardHeader>
@@ -76,7 +83,7 @@ export default function EvaluationSection({
             />
           </SectionEvaluationLayout>
           <ProgressBar
-            sectionRates={[{ label: '進捗率', rate: 100 }]}
+            sectionRates={[{ label: '進捗率', rate: progressRate }]}
             label="評価進捗"
           />
           <div className="flex gap-10 justify-around">

--- a/src/app/(protected)/admin/components/evaluation-section.tsx
+++ b/src/app/(protected)/admin/components/evaluation-section.tsx
@@ -7,6 +7,9 @@ import SectionEvaluationDetail from '@/components/evaluation/section-evaluation-
 import { Label } from '@/components/ui/label';
 import ProgressBar from '@/components/evaluation/progress-bar';
 import { Button } from '@/components/ui/button';
+import { TotalEvaluations } from '../../../../../types/evaluations';
+import { calcEvaluation } from '@/lib/utils/evaluation-calc';
+import { formatCategoryRates } from '@/lib/utils/evaluation-format';
 
 type EvaluationPeriod = Pick<
   Tables<'evaluation_periods'>,
@@ -15,6 +18,7 @@ type EvaluationPeriod = Pick<
 
 type EvaluationSectionProps = {
   evaluationPeriods: EvaluationPeriod[];
+  totalEvaluations: TotalEvaluations[];
   currentEvaluationPeriod?: EvaluationPeriod;
   label: string;
 };
@@ -22,8 +26,16 @@ type EvaluationSectionProps = {
 export default function EvaluationSection({
   evaluationPeriods,
   currentEvaluationPeriod,
+  totalEvaluations,
   label,
 }: EvaluationSectionProps) {
+  const allSections = totalEvaluations.flatMap((v) => v.evaluation_sections);
+  const totalEvaluation = calcEvaluation(allSections);
+  const formattedData = formatCategoryRates(
+    totalEvaluation.skillRate,
+    totalEvaluation.hospitalityRate,
+    totalEvaluation.cleanlinessRate
+  );
   return (
     <Card>
       <CardHeader>
@@ -55,16 +67,12 @@ export default function EvaluationSection({
           </Label>
           <SectionEvaluationLayout>
             <SectionEvaluationDetail
-              rank="A"
-              rate={100}
-              skillRate={100}
-              hospitalityRate={100}
-              cleanlinessRate={100}
-              categoryItems={[
-                { label: 'スキル', rate: 100 },
-                { label: 'ホスピタリティ', rate: 100 },
-                { label: 'クレンリネス', rate: 100 },
-              ]}
+              rank={totalEvaluation.rank}
+              rate={totalEvaluation.rate}
+              skillRate={totalEvaluation.skillRate}
+              hospitalityRate={totalEvaluation.hospitalityRate}
+              cleanlinessRate={totalEvaluation.cleanlinessRate}
+              categoryItems={formattedData}
             />
           </SectionEvaluationLayout>
           <ProgressBar

--- a/src/app/(protected)/admin/components/evaluation-section.tsx
+++ b/src/app/(protected)/admin/components/evaluation-section.tsx
@@ -2,6 +2,9 @@ import { Icons } from '@/components/icon/icons';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import EvaluationPeriodSelect from './evaluation-period-select';
 import { Tables } from '../../../../../types/supabase';
+import SectionEvaluationLayout from '@/components/evaluation/section-evaluation-layout';
+import SectionEvaluationDetail from '@/components/evaluation/section-evaluation-detail';
+import { Label } from '@/components/ui/label';
 
 type EvaluationPeriod = Pick<
   Tables<'evaluation_periods'>,
@@ -29,8 +32,8 @@ export default function EvaluationSection({
           {label}
         </CardTitle>
       </CardHeader>
-      <CardContent>
-        <div className="space-y-2 mb-2">
+      <CardContent className="space-y-10">
+        <div>
           <p className="text-sm text-muted-foreground">
             現在の期間:
             {currentEvaluationPeriod ? (
@@ -45,6 +48,24 @@ export default function EvaluationSection({
           </p>
         </div>
         <EvaluationPeriodSelect evaluationPeriods={evaluationPeriods} />
+        <Label>
+          <span className="size-2 bg-primary rounded-full" />
+          店舗全体評価
+        </Label>
+        <SectionEvaluationLayout>
+          <SectionEvaluationDetail
+            rank="A"
+            rate={100}
+            skillRate={100}
+            hospitalityRate={100}
+            cleanlinessRate={100}
+            categoryItems={[
+              { label: 'スキル', rate: 100 },
+              { label: 'ホスピタリティ', rate: 100 },
+              { label: 'クレンリネス', rate: 100 },
+            ]}
+          />
+        </SectionEvaluationLayout>
       </CardContent>
     </Card>
   );

--- a/src/app/(protected)/admin/components/evaluation-section.tsx
+++ b/src/app/(protected)/admin/components/evaluation-section.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Icons } from '@/components/icon/icons';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import EvaluationPeriodSelect from './evaluation-period-select';
@@ -13,6 +15,15 @@ import { formatCategoryRates } from '@/lib/utils/evaluation-format';
 import { Staff } from '../../../../../types/staff';
 import Image from 'next/image';
 import Link from 'next/link';
+import { useState } from 'react';
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from '@/components/ui/pagination';
 
 type EvaluationPeriod = Pick<
   Tables<'evaluation_periods'>,
@@ -55,6 +66,15 @@ export default function EvaluationSection({
     (staff) =>
       !totalEvaluations.some((evaluation) => evaluation.staff_id === staff.id)
   );
+  const [currentPage, setCurrentPage] = useState(1);
+  const pageSize = 4;
+  const startIndex = (currentPage - 1) * pageSize;
+  const currentItems = unevaluatedStaffLists.slice(
+    startIndex,
+    startIndex + pageSize
+  );
+  const totalPage = Math.ceil(unevaluatedStaffLists.length / pageSize);
+
   return (
     <Card>
       <CardHeader>
@@ -123,7 +143,7 @@ export default function EvaluationSection({
             未評価スタッフ一覧
           </Label>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-            {unevaluatedStaffLists.map((staff) => (
+            {currentItems.map((staff) => (
               <UnevaluatedStaffCard
                 key={staff.id}
                 staff={staff}
@@ -131,6 +151,32 @@ export default function EvaluationSection({
               />
             ))}
           </div>
+          <Pagination>
+            <PaginationContent>
+              <PaginationItem>
+                <PaginationPrevious
+                  onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+                />
+              </PaginationItem>
+              {[...Array(totalPage)].map((_, i) => (
+                <PaginationItem key={i}>
+                  <PaginationLink
+                    isActive={currentPage === i + 1}
+                    onClick={() => setCurrentPage(i + 1)}
+                  >
+                    {i + 1}
+                  </PaginationLink>
+                </PaginationItem>
+              ))}
+              <PaginationItem>
+                <PaginationNext
+                  onClick={() =>
+                    setCurrentPage((p) => Math.min(totalPage, p + 1))
+                  }
+                />
+              </PaginationItem>
+            </PaginationContent>
+          </Pagination>
         </div>
       </CardContent>
     </Card>

--- a/src/app/(protected)/admin/components/evaluation-section.tsx
+++ b/src/app/(protected)/admin/components/evaluation-section.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { Icons } from '@/components/icon/icons';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import EvaluationPeriodSelect from './evaluation-period-select';
@@ -8,18 +6,9 @@ import SectionEvaluationLayout from '@/components/evaluation/section-evaluation-
 import SectionEvaluationDetail from '@/components/evaluation/section-evaluation-detail';
 import { Label } from '@/components/ui/label';
 import ProgressBar from '@/components/evaluation/progress-bar';
-import { Button } from '@/components/ui/button';
 import { FormattedSectionRate } from '@/lib/utils/evaluation-format';
 import { Staff } from '../../../../../types/staff';
-import Image from 'next/image';
-import Link from 'next/link';
-import { useState } from 'react';
-import {
-  Pagination,
-  PaginationContent,
-  PaginationItem,
-  PaginationLink,
-} from '@/components/ui/pagination';
+import UnevaluatedStaffList from './unevaluated-staff-list';
 
 type EvaluationPeriod = Pick<
   Tables<'evaluation_periods'>,
@@ -40,16 +29,6 @@ type EvaluationSectionProps = {
   unevaluatedStaffs: number;
   unevaluatedStaffLists: Staff[];
   label: string;
-};
-
-type UnevaluatedStaffCardProps = {
-  staff: Staff;
-  periodId?: string;
-};
-
-type UnevaluatedStaffListProps = {
-  unevaluatedStaffLists: Staff[];
-  currentEvaluationPeriod?: string;
 };
 
 export default function EvaluationSection({
@@ -141,99 +120,5 @@ export default function EvaluationSection({
         </div>
       </CardContent>
     </Card>
-  );
-}
-
-function UnevaluatedStaffCard({ staff, periodId }: UnevaluatedStaffCardProps) {
-  return (
-    <Card>
-      <CardContent className="pb-4">
-        <div className="flex flex-col justify-center gap-y-5">
-          <div className="flex items-center justify-center gap-2">
-            <div className="w-10 h-10 rounded-full bg-card flex items-center justify-center overflow-hidden shrink-0">
-              {staff.avatar_url ? (
-                <Image
-                  src={staff.avatar_url}
-                  alt={staff.name}
-                  width={40}
-                  height={40}
-                  className="object-cover"
-                />
-              ) : (
-                <Icons.UserCircle className="h-10 w-10 text-muted-foreground" />
-              )}
-            </div>
-            <span className="font-medium text-sm">{staff.name}</span>
-          </div>
-          <Button size="sm" variant="ghost" className="text-primary" asChild>
-            <Link
-              href={`/admin/staff/${staff.id}/evaluation?periodId=${periodId}`}
-            >
-              評価する
-              <Icons.ArrowBigRight className="w-5 h-5" />
-            </Link>
-          </Button>
-        </div>
-      </CardContent>
-    </Card>
-  );
-}
-
-function UnevaluatedStaffList({
-  unevaluatedStaffLists,
-  currentEvaluationPeriod,
-}: UnevaluatedStaffListProps) {
-  const [currentPage, setCurrentPage] = useState(1);
-  const pageSize = 6;
-  const startIndex = (currentPage - 1) * pageSize;
-  const currentItems = unevaluatedStaffLists.slice(
-    startIndex,
-    startIndex + pageSize
-  );
-  const totalPage = Math.ceil(unevaluatedStaffLists.length / pageSize);
-  return (
-    <>
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        {currentItems.map((staff) => (
-          <UnevaluatedStaffCard
-            key={staff.id}
-            staff={staff}
-            periodId={currentEvaluationPeriod}
-          />
-        ))}
-      </div>
-      <Pagination>
-        <PaginationContent>
-          <PaginationItem>
-            <button
-              onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
-              disabled={currentPage === 1}
-              className="disabled:opacity-50"
-            >
-              <Icons.ChevronLeft className="w-4 h-4" />
-            </button>
-          </PaginationItem>
-          {[...Array(totalPage)].map((_, i) => (
-            <PaginationItem key={i}>
-              <PaginationLink
-                isActive={currentPage === i + 1}
-                onClick={() => setCurrentPage(i + 1)}
-              >
-                {i + 1}
-              </PaginationLink>
-            </PaginationItem>
-          ))}
-          <PaginationItem>
-            <button
-              onClick={() => setCurrentPage((p) => Math.min(totalPage, p + 1))}
-              disabled={currentPage === totalPage}
-              className="disabled:opacity-50"
-            >
-              <Icons.ChevronRight className="w-4 h-4" />
-            </button>
-          </PaginationItem>
-        </PaginationContent>
-      </Pagination>
-    </>
   );
 }

--- a/src/app/(protected)/admin/components/evaluation-section.tsx
+++ b/src/app/(protected)/admin/components/evaluation-section.tsx
@@ -33,18 +33,16 @@ export default function EvaluationSection({
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-10">
-        <div>
+        <div className="flex flex-col gap-1">
+          <Label>
+            <Icons.CalendarDays className="w-5 h-5" />
+            現在の評価期間
+          </Label>
+
           <p className="text-sm text-muted-foreground">
-            現在の期間:
-            {currentEvaluationPeriod ? (
-              <span className="font-medium text-foreground">
-                {currentEvaluationPeriod.name}
-              </span>
-            ) : (
-              <span className="font-medium text-foreground">
-                評価期間を作成して設定してください
-              </span>
-            )}
+            {currentEvaluationPeriod
+              ? currentEvaluationPeriod.name
+              : '評価期間を作成して設定してください'}
           </p>
         </div>
         <EvaluationPeriodSelect evaluationPeriods={evaluationPeriods} />

--- a/src/app/(protected)/admin/components/evaluation-section.tsx
+++ b/src/app/(protected)/admin/components/evaluation-section.tsx
@@ -41,6 +41,11 @@ type UnevaluatedStaffCardProps = {
   periodId?: string;
 };
 
+type UnevaluatedStaffListProps = {
+  unevaluatedStaffLists: Staff[];
+  currentEvaluationPeriod?: string;
+};
+
 export default function EvaluationSection({
   evaluationPeriods,
   currentEvaluationPeriod,
@@ -64,14 +69,6 @@ export default function EvaluationSection({
     (staff) =>
       !totalEvaluations.some((evaluation) => evaluation.staff_id === staff.id)
   );
-  const [currentPage, setCurrentPage] = useState(1);
-  const pageSize = 6;
-  const startIndex = (currentPage - 1) * pageSize;
-  const currentItems = unevaluatedStaffLists.slice(
-    startIndex,
-    startIndex + pageSize
-  );
-  const totalPage = Math.ceil(unevaluatedStaffLists.length / pageSize);
 
   return (
     <Card>
@@ -140,49 +137,10 @@ export default function EvaluationSection({
             <span className="size-2 bg-primary rounded-full" />
             未評価スタッフ一覧
           </Label>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-            {currentItems.map((staff) => (
-              <UnevaluatedStaffCard
-                key={staff.id}
-                staff={staff}
-                periodId={currentEvaluationPeriod?.id}
-              />
-            ))}
-          </div>
-          <Pagination>
-            <PaginationContent>
-              <PaginationItem>
-                <button
-                  onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
-                  disabled={currentPage === 1}
-                  className="disabled:opacity-50"
-                >
-                  <Icons.ChevronLeft className="w-4 h-4" />
-                </button>
-              </PaginationItem>
-              {[...Array(totalPage)].map((_, i) => (
-                <PaginationItem key={i}>
-                  <PaginationLink
-                    isActive={currentPage === i + 1}
-                    onClick={() => setCurrentPage(i + 1)}
-                  >
-                    {i + 1}
-                  </PaginationLink>
-                </PaginationItem>
-              ))}
-              <PaginationItem>
-                <button
-                  onClick={() =>
-                    setCurrentPage((p) => Math.min(totalPage, p + 1))
-                  }
-                  disabled={currentPage === totalPage}
-                  className="disabled:opacity-50"
-                >
-                  <Icons.ChevronRight className="w-4 h-4" />
-                </button>
-              </PaginationItem>
-            </PaginationContent>
-          </Pagination>
+          <UnevaluatedStaffList
+            currentEvaluationPeriod={currentEvaluationPeriod?.id}
+            unevaluatedStaffLists={unevaluatedStaffLists}
+          />
         </div>
       </CardContent>
     </Card>
@@ -221,5 +179,64 @@ function UnevaluatedStaffCard({ staff, periodId }: UnevaluatedStaffCardProps) {
         </div>
       </CardContent>
     </Card>
+  );
+}
+
+function UnevaluatedStaffList({
+  unevaluatedStaffLists,
+  currentEvaluationPeriod,
+}: UnevaluatedStaffListProps) {
+  const [currentPage, setCurrentPage] = useState(1);
+  const pageSize = 6;
+  const startIndex = (currentPage - 1) * pageSize;
+  const currentItems = unevaluatedStaffLists.slice(
+    startIndex,
+    startIndex + pageSize
+  );
+  const totalPage = Math.ceil(unevaluatedStaffLists.length / pageSize);
+  return (
+    <>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {currentItems.map((staff) => (
+          <UnevaluatedStaffCard
+            key={staff.id}
+            staff={staff}
+            periodId={currentEvaluationPeriod}
+          />
+        ))}
+      </div>
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <button
+              onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+              disabled={currentPage === 1}
+              className="disabled:opacity-50"
+            >
+              <Icons.ChevronLeft className="w-4 h-4" />
+            </button>
+          </PaginationItem>
+          {[...Array(totalPage)].map((_, i) => (
+            <PaginationItem key={i}>
+              <PaginationLink
+                isActive={currentPage === i + 1}
+                onClick={() => setCurrentPage(i + 1)}
+              >
+                {i + 1}
+              </PaginationLink>
+            </PaginationItem>
+          ))}
+          <PaginationItem>
+            <button
+              onClick={() => setCurrentPage((p) => Math.min(totalPage, p + 1))}
+              disabled={currentPage === totalPage}
+              className="disabled:opacity-50"
+            >
+              <Icons.ChevronRight className="w-4 h-4" />
+            </button>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    </>
   );
 }

--- a/src/app/(protected)/admin/components/evaluation-section.tsx
+++ b/src/app/(protected)/admin/components/evaluation-section.tsx
@@ -5,6 +5,7 @@ import { Tables } from '../../../../../types/supabase';
 import SectionEvaluationLayout from '@/components/evaluation/section-evaluation-layout';
 import SectionEvaluationDetail from '@/components/evaluation/section-evaluation-detail';
 import { Label } from '@/components/ui/label';
+import ProgressBar from '@/components/evaluation/progress-bar';
 
 type EvaluationPeriod = Pick<
   Tables<'evaluation_periods'>,
@@ -32,27 +33,27 @@ export default function EvaluationSection({
           {label}
         </CardTitle>
       </CardHeader>
-      <CardContent className="space-y-10">
-        <div className="flex flex-col-reverse gap-y-8 sm:flex-row sm:justify-between">
-          <div className="flex flex-col gap-1">
-            <Label>
-              <Icons.CalendarDays className="w-5 h-5" />
-              現在の評価期間
-            </Label>
-
-            <p className="text-sm text-muted-foreground">
-              {currentEvaluationPeriod
-                ? currentEvaluationPeriod.name
-                : '評価期間を作成して設定してください'}
-            </p>
-          </div>
-          <EvaluationPeriodSelect evaluationPeriods={evaluationPeriods} />
-        </div>
-        <Label>
-          <span className="size-2 bg-primary rounded-full" />
-          店舗全体評価
-        </Label>
+      <CardContent>
         <SectionEvaluationLayout>
+          <div className="flex flex-col-reverse gap-y-8 sm:flex-row sm:justify-between">
+            <div className="flex flex-col gap-1">
+              <Label>
+                <Icons.CalendarDays className="w-5 h-5" />
+                現在の評価期間
+              </Label>
+
+              <p className="text-sm text-muted-foreground">
+                {currentEvaluationPeriod
+                  ? currentEvaluationPeriod.name
+                  : '評価期間を作成して設定してください'}
+              </p>
+            </div>
+            <EvaluationPeriodSelect evaluationPeriods={evaluationPeriods} />
+          </div>
+          <Label>
+            <span className="size-2 bg-primary rounded-full" />
+            店舗全体評価
+          </Label>
           <SectionEvaluationDetail
             rank="A"
             rate={100}
@@ -64,6 +65,10 @@ export default function EvaluationSection({
               { label: 'ホスピタリティ', rate: 100 },
               { label: 'クレンリネス', rate: 100 },
             ]}
+          />
+          <ProgressBar
+            sectionRates={[{ label: '進捗率', rate: 100 }]}
+            label="評価進捗"
           />
         </SectionEvaluationLayout>
       </CardContent>

--- a/src/app/(protected)/admin/components/evaluation-section.tsx
+++ b/src/app/(protected)/admin/components/evaluation-section.tsx
@@ -9,9 +9,7 @@ import SectionEvaluationDetail from '@/components/evaluation/section-evaluation-
 import { Label } from '@/components/ui/label';
 import ProgressBar from '@/components/evaluation/progress-bar';
 import { Button } from '@/components/ui/button';
-import { TotalEvaluations } from '../../../../../types/evaluations';
-import { calcEvaluation } from '@/lib/utils/evaluation-calc';
-import { formatCategoryRates } from '@/lib/utils/evaluation-format';
+import { FormattedSectionRate } from '@/lib/utils/evaluation-format';
 import { Staff } from '../../../../../types/staff';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -30,9 +28,17 @@ type EvaluationPeriod = Pick<
 
 type EvaluationSectionProps = {
   evaluationPeriods: EvaluationPeriod[];
-  totalEvaluations: TotalEvaluations[];
   currentEvaluationPeriod?: EvaluationPeriod;
-  staffLists: Staff[];
+  rate: number;
+  rank: string;
+  skillRate: number;
+  hospitalityRate: number;
+  cleanlinessRate: number;
+  formattedData: FormattedSectionRate[];
+  progressRate: number;
+  evaluatedStaffs: number;
+  unevaluatedStaffs: number;
+  unevaluatedStaffLists: Staff[];
   label: string;
 };
 
@@ -49,27 +55,18 @@ type UnevaluatedStaffListProps = {
 export default function EvaluationSection({
   evaluationPeriods,
   currentEvaluationPeriod,
-  totalEvaluations,
-  staffLists,
+  rank,
+  rate,
+  skillRate,
+  hospitalityRate,
+  cleanlinessRate,
+  formattedData,
+  progressRate,
+  evaluatedStaffs,
+  unevaluatedStaffs,
+  unevaluatedStaffLists,
   label,
 }: EvaluationSectionProps) {
-  const allSections = totalEvaluations.flatMap((v) => v.evaluation_sections);
-  const totalEvaluation = calcEvaluation(allSections);
-  const formattedData = formatCategoryRates(
-    totalEvaluation.skillRate,
-    totalEvaluation.hospitalityRate,
-    totalEvaluation.cleanlinessRate
-  );
-  const totalStaffs = staffLists.length;
-  const evaluatedStaffs = totalEvaluations.length;
-  const progressRate =
-    totalStaffs > 0 ? Math.round((evaluatedStaffs / totalStaffs) * 100) : 0;
-  const unevaluatedStaffs = totalStaffs - evaluatedStaffs;
-  const unevaluatedStaffLists = staffLists.filter(
-    (staff) =>
-      !totalEvaluations.some((evaluation) => evaluation.staff_id === staff.id)
-  );
-
   return (
     <Card>
       <CardHeader>
@@ -101,11 +98,11 @@ export default function EvaluationSection({
           </Label>
           <SectionEvaluationLayout>
             <SectionEvaluationDetail
-              rank={totalEvaluation.rank}
-              rate={totalEvaluation.rate}
-              skillRate={totalEvaluation.skillRate}
-              hospitalityRate={totalEvaluation.hospitalityRate}
-              cleanlinessRate={totalEvaluation.cleanlinessRate}
+              rank={rank}
+              rate={rate}
+              skillRate={skillRate}
+              hospitalityRate={hospitalityRate}
+              cleanlinessRate={cleanlinessRate}
               categoryItems={formattedData}
             />
           </SectionEvaluationLayout>

--- a/src/app/(protected)/admin/components/evaluation-section.tsx
+++ b/src/app/(protected)/admin/components/evaluation-section.tsx
@@ -34,7 +34,7 @@ export default function EvaluationSection({
         </CardTitle>
       </CardHeader>
       <CardContent>
-        <SectionEvaluationLayout>
+        <div className="mt-15 max-w-200 mx-auto space-y-16">
           <div className="flex flex-col-reverse gap-y-8 sm:flex-row sm:justify-between">
             <div className="flex flex-col gap-1">
               <Label>
@@ -54,23 +54,25 @@ export default function EvaluationSection({
             <span className="size-2 bg-primary rounded-full" />
             店舗全体評価
           </Label>
-          <SectionEvaluationDetail
-            rank="A"
-            rate={100}
-            skillRate={100}
-            hospitalityRate={100}
-            cleanlinessRate={100}
-            categoryItems={[
-              { label: 'スキル', rate: 100 },
-              { label: 'ホスピタリティ', rate: 100 },
-              { label: 'クレンリネス', rate: 100 },
-            ]}
-          />
+          <SectionEvaluationLayout>
+            <SectionEvaluationDetail
+              rank="A"
+              rate={100}
+              skillRate={100}
+              hospitalityRate={100}
+              cleanlinessRate={100}
+              categoryItems={[
+                { label: 'スキル', rate: 100 },
+                { label: 'ホスピタリティ', rate: 100 },
+                { label: 'クレンリネス', rate: 100 },
+              ]}
+            />
+          </SectionEvaluationLayout>
           <ProgressBar
             sectionRates={[{ label: '進捗率', rate: 100 }]}
             label="評価進捗"
           />
-        </SectionEvaluationLayout>
+        </div>
       </CardContent>
     </Card>
   );

--- a/src/app/(protected)/admin/components/evaluation-section.tsx
+++ b/src/app/(protected)/admin/components/evaluation-section.tsx
@@ -55,7 +55,7 @@ export default function EvaluationSection({
         </CardTitle>
       </CardHeader>
       <CardContent>
-        <div className="mt-15 max-w-200 mx-auto space-y-16">
+        <div className="max-w-200 mx-auto space-y-16">
           <div className="flex flex-col-reverse gap-y-8 sm:flex-row sm:justify-between">
             <div className="flex flex-col gap-1">
               <Label>

--- a/src/app/(protected)/admin/components/unevaluated-staff-list.tsx
+++ b/src/app/(protected)/admin/components/unevaluated-staff-list.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { useState } from 'react';
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+} from '@/components/ui/pagination';
+import { Staff } from '../../../../../types/staff';
+import { Icons } from '@/components/icon/icons';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+
+type UnevaluatedStaffCardProps = {
+  staff: Staff;
+  periodId?: string;
+};
+
+type UnevaluatedStaffListProps = {
+  unevaluatedStaffLists: Staff[];
+  currentEvaluationPeriod?: string;
+};
+
+export default function UnevaluatedStaffList({
+  unevaluatedStaffLists,
+  currentEvaluationPeriod,
+}: UnevaluatedStaffListProps) {
+  const [currentPage, setCurrentPage] = useState(1);
+  const pageSize = 6;
+  const startIndex = (currentPage - 1) * pageSize;
+  const currentItems = unevaluatedStaffLists.slice(
+    startIndex,
+    startIndex + pageSize
+  );
+  const totalPage = Math.ceil(unevaluatedStaffLists.length / pageSize);
+  return (
+    <>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {currentItems.map((staff) => (
+          <UnevaluatedStaffCard
+            key={staff.id}
+            staff={staff}
+            periodId={currentEvaluationPeriod}
+          />
+        ))}
+      </div>
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <button
+              onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+              disabled={currentPage === 1}
+              className="disabled:opacity-50"
+            >
+              <Icons.ChevronLeft className="w-4 h-4" />
+            </button>
+          </PaginationItem>
+          {[...Array(totalPage)].map((_, i) => (
+            <PaginationItem key={i}>
+              <PaginationLink
+                isActive={currentPage === i + 1}
+                onClick={() => setCurrentPage(i + 1)}
+              >
+                {i + 1}
+              </PaginationLink>
+            </PaginationItem>
+          ))}
+          <PaginationItem>
+            <button
+              onClick={() => setCurrentPage((p) => Math.min(totalPage, p + 1))}
+              disabled={currentPage === totalPage}
+              className="disabled:opacity-50"
+            >
+              <Icons.ChevronRight className="w-4 h-4" />
+            </button>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    </>
+  );
+}
+
+function UnevaluatedStaffCard({ staff, periodId }: UnevaluatedStaffCardProps) {
+  return (
+    <Card>
+      <CardContent className="pb-4">
+        <div className="flex flex-col justify-center gap-y-5">
+          <div className="flex items-center justify-center gap-2">
+            <div className="w-10 h-10 rounded-full bg-card flex items-center justify-center overflow-hidden shrink-0">
+              {staff.avatar_url ? (
+                <Image
+                  src={staff.avatar_url}
+                  alt={staff.name}
+                  width={40}
+                  height={40}
+                  className="object-cover"
+                />
+              ) : (
+                <Icons.UserCircle className="h-10 w-10 text-muted-foreground" />
+              )}
+            </div>
+            <span className="font-medium text-sm">{staff.name}</span>
+          </div>
+          <Button size="sm" variant="ghost" className="text-primary" asChild>
+            <Link
+              href={`/admin/staff/${staff.id}/evaluation?periodId=${periodId}`}
+            >
+              評価する
+              <Icons.ArrowBigRight className="w-5 h-5" />
+            </Link>
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(protected)/admin/page.tsx
+++ b/src/app/(protected)/admin/page.tsx
@@ -4,6 +4,7 @@ import EvaluationPeriodList from './components/evaluation-period-list';
 import AdminContainer from './components/admin-contaimer';
 import EvaluationSection from './components/evaluation-section';
 import { requireAdmin } from '@/lib/utils/requireAdmin';
+import { TotalEvaluations } from '../../../../types/evaluations';
 
 export default async function AdminPage() {
   const supabase = await createClient();
@@ -21,8 +22,8 @@ export default async function AdminPage() {
     (period) => period.is_current
   );
 
-  const { data } = currentEvaluationPeriod
-    ? await supabase
+  const { data: totalEvaluations } = currentEvaluationPeriod
+    ? ((await supabase
         .from('evaluations')
         .select(
           `
@@ -36,17 +37,15 @@ export default async function AdminPage() {
       hospitality_score,
       hospitality_max,
       cleanliness_score,
-      cleanliness_max,
-        evaluation_items(
-          item_name,
-          category,
-          score
-        )
+      cleanliness_max
       )
     `
         )
         .eq('evaluation_period_id', currentEvaluationPeriod.id)
-        .eq('organization_id', orgId)
+        .eq('organization_id', orgId)) as {
+        data: TotalEvaluations[] | null;
+        error: unknown;
+      })
     : { data: null };
 
   return (

--- a/src/app/(protected)/admin/page.tsx
+++ b/src/app/(protected)/admin/page.tsx
@@ -36,7 +36,7 @@ export default async function AdminPage() {
         .select(
           `
     id,
-    status,
+    staff_id,
       evaluation_sections (
       id,
       section_type,

--- a/src/app/(protected)/admin/page.tsx
+++ b/src/app/(protected)/admin/page.tsx
@@ -6,6 +6,8 @@ import EvaluationSection from './components/evaluation-section';
 import { requireAdmin } from '@/lib/utils/requireAdmin';
 import { TotalEvaluations } from '../../../../types/evaluations';
 import { redirect } from 'next/navigation';
+import { calcEvaluation } from '@/lib/utils/evaluation-calc';
+import { formatCategoryRates } from '@/lib/utils/evaluation-format';
 
 export default async function AdminPage() {
   const supabase = await createClient();
@@ -56,6 +58,25 @@ export default async function AdminPage() {
       })
     : { data: null };
 
+  const allSections =
+    totalEvaluations?.flatMap((v) => v.evaluation_sections) ?? [];
+  const totalEvaluation = calcEvaluation(allSections);
+  const formattedData = formatCategoryRates(
+    totalEvaluation.skillRate,
+    totalEvaluation.hospitalityRate,
+    totalEvaluation.cleanlinessRate
+  );
+
+  const totalStaffs = staffs.length;
+  const evaluatedStaffs = totalEvaluations?.length ?? 0;
+  const progressRate =
+    totalStaffs > 0 ? Math.round((evaluatedStaffs / totalStaffs) * 100) : 0;
+  const unevaluatedStaffs = totalStaffs - evaluatedStaffs;
+  const unevaluatedStaffLists = staffs.filter(
+    (staff) =>
+      !totalEvaluations?.some((evaluation) => evaluation.staff_id === staff.id)
+  );
+
   return (
     <AdminContainer>
       <div className="flex flex-col lg:flex-row gap-6">
@@ -67,8 +88,16 @@ export default async function AdminPage() {
       <EvaluationSection
         evaluationPeriods={evaluationPeriods}
         currentEvaluationPeriod={currentEvaluationPeriod}
-        totalEvaluations={totalEvaluations ?? []}
-        staffLists={staffs ?? []}
+        rank={totalEvaluation.rank}
+        rate={totalEvaluation.rate}
+        skillRate={totalEvaluation.skillRate}
+        hospitalityRate={totalEvaluation.hospitalityRate}
+        cleanlinessRate={totalEvaluation.cleanlinessRate}
+        formattedData={formattedData}
+        progressRate={progressRate}
+        evaluatedStaffs={evaluatedStaffs}
+        unevaluatedStaffs={unevaluatedStaffs}
+        unevaluatedStaffLists={unevaluatedStaffLists}
         label="評価"
       />
     </AdminContainer>

--- a/src/app/(protected)/admin/page.tsx
+++ b/src/app/(protected)/admin/page.tsx
@@ -5,11 +5,19 @@ import AdminContainer from './components/admin-contaimer';
 import EvaluationSection from './components/evaluation-section';
 import { requireAdmin } from '@/lib/utils/requireAdmin';
 import { TotalEvaluations } from '../../../../types/evaluations';
+import { redirect } from 'next/navigation';
 
 export default async function AdminPage() {
   const supabase = await createClient();
 
   const { orgId, profile } = await requireAdmin(supabase);
+
+  const { data: staffs, error: staffError } = await supabase
+    .from('profiles')
+    .select('id, name, role, store_name, avatar_url, email')
+    .eq('organization_id', orgId)
+    .eq('role', 'staff');
+  if (staffError) redirect('/admin');
 
   const { data: evaluationPeriods, error: periodsError } = await supabase
     .from('evaluation_periods')
@@ -60,6 +68,7 @@ export default async function AdminPage() {
         evaluationPeriods={evaluationPeriods}
         currentEvaluationPeriod={currentEvaluationPeriod}
         totalEvaluations={totalEvaluations ?? []}
+        staffLists={staffs ?? []}
         label="評価"
       />
     </AdminContainer>

--- a/src/app/(protected)/admin/page.tsx
+++ b/src/app/(protected)/admin/page.tsx
@@ -59,6 +59,7 @@ export default async function AdminPage() {
       <EvaluationSection
         evaluationPeriods={evaluationPeriods}
         currentEvaluationPeriod={currentEvaluationPeriod}
+        totalEvaluations={totalEvaluations ?? []}
         label="評価"
       />
     </AdminContainer>

--- a/src/app/(protected)/admin/page.tsx
+++ b/src/app/(protected)/admin/page.tsx
@@ -57,7 +57,11 @@ export default async function AdminPage() {
         </div>
         <EvaluationPeriodList evaluationPeriods={evaluationPeriods} />
       </div>
-      <EvaluationSection evaluationPeriods={evaluationPeriods} label="評価" />
+      <EvaluationSection
+        evaluationPeriods={evaluationPeriods}
+        currentEvaluationPeriod={currentEvaluationPeriod}
+        label="評価"
+      />
     </AdminContainer>
   );
 }

--- a/src/app/(protected)/admin/page.tsx
+++ b/src/app/(protected)/admin/page.tsx
@@ -17,6 +17,38 @@ export default async function AdminPage() {
 
   if (periodsError || !evaluationPeriods) return;
 
+  const currentEvaluationPeriod = evaluationPeriods.find(
+    (period) => period.is_current
+  );
+
+  const { data } = currentEvaluationPeriod
+    ? await supabase
+        .from('evaluations')
+        .select(
+          `
+    id,
+    status,
+      evaluation_sections (
+      id,
+      section_type,
+      skill_score,
+      skill_max,
+      hospitality_score,
+      hospitality_max,
+      cleanliness_score,
+      cleanliness_max,
+        evaluation_items(
+          item_name,
+          category,
+          score
+        )
+      )
+    `
+        )
+        .eq('evaluation_period_id', currentEvaluationPeriod.id)
+        .eq('organization_id', orgId)
+    : { data: null };
+
   return (
     <AdminContainer>
       <div className="flex flex-col lg:flex-row gap-6">
@@ -25,10 +57,7 @@ export default async function AdminPage() {
         </div>
         <EvaluationPeriodList evaluationPeriods={evaluationPeriods} />
       </div>
-      <EvaluationSection
-        evaluationPeriods={evaluationPeriods}
-        label="評価"
-      />
+      <EvaluationSection evaluationPeriods={evaluationPeriods} label="評価" />
     </AdminContainer>
   );
 }

--- a/src/app/(protected)/admin/staff/components/staff-card.tsx
+++ b/src/app/(protected)/admin/staff/components/staff-card.tsx
@@ -25,8 +25,6 @@ export default function StaffCard({
     ? calcEvaluation(staffEvaluation.evaluation_sections)
     : null;
 
-    console.log(evaluation)
-
   return (
     <Card className="relative">
       <CardContent className="pb-4">

--- a/src/components/icon/icons.tsx
+++ b/src/components/icon/icons.tsx
@@ -34,6 +34,7 @@ import {
   X,
   CircleAlert,
   Check,
+  ArrowBigRight
 } from 'lucide-react';
 
 import { FaXTwitter, FaGithub } from 'react-icons/fa6';
@@ -83,6 +84,7 @@ export const Icons = {
   X,
   CircleAlert,
   Check,
+  ArrowBigRight,
   FaXTwitter,
   FaGithub,
   FcGoogle,

--- a/src/components/icon/icons.tsx
+++ b/src/components/icon/icons.tsx
@@ -33,6 +33,7 @@ import {
   Sprout,
   X,
   CircleAlert,
+  Check,
 } from 'lucide-react';
 
 import { FaXTwitter, FaGithub } from 'react-icons/fa6';
@@ -81,6 +82,7 @@ export const Icons = {
   Sprout,
   X,
   CircleAlert,
+  Check,
   FaXTwitter,
   FaGithub,
   FcGoogle,

--- a/src/components/icon/icons.tsx
+++ b/src/components/icon/icons.tsx
@@ -34,7 +34,9 @@ import {
   X,
   CircleAlert,
   Check,
-  ArrowBigRight
+  ArrowBigRight,
+  ChevronLeft,
+  ChevronRight,
 } from 'lucide-react';
 
 import { FaXTwitter, FaGithub } from 'react-icons/fa6';
@@ -85,6 +87,8 @@ export const Icons = {
   CircleAlert,
   Check,
   ArrowBigRight,
+  ChevronLeft,
+  ChevronRight,
   FaXTwitter,
   FaGithub,
   FcGoogle,

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,15 +5,15 @@ import { Slot } from "radix-ui"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
         default: "bg-primary text-primary-foreground hover:bg-primary/90",
         destructive:
-          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40",
         outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost:
@@ -23,7 +23,7 @@ const buttonVariants = cva(
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
         xs: "h-6 gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+        sm: "h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5",
         lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
         icon: "size-9",
         "icon-xs": "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -1,0 +1,127 @@
+import * as React from "react"
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  MoreHorizontalIcon,
+} from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants, type Button } from "@/components/ui/button"
+
+function Pagination({ className, ...props }: React.ComponentProps<"nav">) {
+  return (
+    <nav
+      role="navigation"
+      aria-label="pagination"
+      data-slot="pagination"
+      className={cn("mx-auto flex w-full justify-center", className)}
+      {...props}
+    />
+  )
+}
+
+function PaginationContent({
+  className,
+  ...props
+}: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="pagination-content"
+      className={cn("flex flex-row items-center gap-1", className)}
+      {...props}
+    />
+  )
+}
+
+function PaginationItem({ ...props }: React.ComponentProps<"li">) {
+  return <li data-slot="pagination-item" {...props} />
+}
+
+type PaginationLinkProps = {
+  isActive?: boolean
+} & Pick<React.ComponentProps<typeof Button>, "size"> &
+  React.ComponentProps<"a">
+
+function PaginationLink({
+  className,
+  isActive,
+  size = "icon",
+  ...props
+}: PaginationLinkProps) {
+  return (
+    <a
+      aria-current={isActive ? "page" : undefined}
+      data-slot="pagination-link"
+      data-active={isActive}
+      className={cn(
+        buttonVariants({
+          variant: isActive ? "outline" : "ghost",
+          size,
+        }),
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function PaginationPrevious({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) {
+  return (
+    <PaginationLink
+      aria-label="Go to previous page"
+      size="default"
+      className={cn("gap-1 px-2.5 sm:pl-2.5", className)}
+      {...props}
+    >
+      <ChevronLeftIcon />
+      <span className="hidden sm:block">Previous</span>
+    </PaginationLink>
+  )
+}
+
+function PaginationNext({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) {
+  return (
+    <PaginationLink
+      aria-label="Go to next page"
+      size="default"
+      className={cn("gap-1 px-2.5 sm:pr-2.5", className)}
+      {...props}
+    >
+      <span className="hidden sm:block">Next</span>
+      <ChevronRightIcon />
+    </PaginationLink>
+  )
+}
+
+function PaginationEllipsis({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      aria-hidden
+      data-slot="pagination-ellipsis"
+      className={cn("flex size-9 items-center justify-center", className)}
+      {...props}
+    >
+      <MoreHorizontalIcon className="size-4" />
+      <span className="sr-only">More pages</span>
+    </span>
+  )
+}
+
+export {
+  Pagination,
+  PaginationContent,
+  PaginationLink,
+  PaginationItem,
+  PaginationPrevious,
+  PaginationNext,
+  PaginationEllipsis,
+}

--- a/types/evaluations.ts
+++ b/types/evaluations.ts
@@ -86,7 +86,10 @@ export type SummaryComment = Pick<
   'action_plan' | 'total_comment' | 'future_vision'
 >;
 
-export type TotalEvaluations = Pick<Tables<'evaluations'>, 'id' | 'status'> & {
+export type TotalEvaluations = Pick<
+  Tables<'evaluations'>,
+  'id' | 'staff_id'
+> & {
   evaluation_sections: (Pick<
     Tables<'evaluation_sections'>,
     | 'id'

--- a/types/evaluations.ts
+++ b/types/evaluations.ts
@@ -87,7 +87,7 @@ export type SummaryComment = Pick<
 >;
 
 export type TotalEvaluations = Pick<Tables<'evaluations'>, 'id' | 'status'> & {
-  evaluation_sections: Pick<
+  evaluation_sections: (Pick<
     Tables<'evaluation_sections'>,
     | 'id'
     | 'skill_score'
@@ -96,8 +96,7 @@ export type TotalEvaluations = Pick<Tables<'evaluations'>, 'id' | 'status'> & {
     | 'hospitality_max'
     | 'cleanliness_score'
     | 'cleanliness_max'
-  > &
-    {
-      section_type: SectionType;
-    }[];
+  > & {
+    section_type: SectionType;
+  })[];
 };

--- a/types/evaluations.ts
+++ b/types/evaluations.ts
@@ -85,3 +85,19 @@ export type SummaryComment = Pick<
   Tables<'evaluations'>,
   'action_plan' | 'total_comment' | 'future_vision'
 >;
+
+export type TotalEvaluations = Pick<Tables<'evaluations'>, 'id' | 'status'> & {
+  evaluation_sections: Pick<
+    Tables<'evaluation_sections'>,
+    | 'id'
+    | 'skill_score'
+    | 'skill_max'
+    | 'hospitality_score'
+    | 'hospitality_max'
+    | 'cleanliness_score'
+    | 'cleanliness_max'
+  > &
+    {
+      section_type: SectionType;
+    }[];
+};


### PR DESCRIPTION
## 概要
管理者ダッシュボードの評価セクションを実装した。
店舗全体の評価表示・評価進捗・未評価スタッフ一覧の３つの機能を含む。

## 対応
#### 4月20日
- 店舗総合評価のUIを実装
- 評価進捗のUIを実装
- 未評価者を表示するUIを実装

#### ４月21日
- 現在の評価に紐づくtotalEvaluationsデータを取得
- currentEvaluationsPeriodを親コンポーネントから渡すように変更
- 評価期間に紐づいたtotalEvaluationsの型を定義

#### 4月22日
-  SectionEvaluationDetailにデータを流し込み総合評価、グラフを表示
- 評価進捗を 表示させるProgressBarコンポーネントにデータを流し込み表示
- 未評価者を絞り込みUnevaluatedStaffCardコンポーネントを表示 

#### 4月23日
- 未評価スタッフ一覧のページネーションを実装
- 未評価スタッフ一覧UIを可読性向上のためコンポーネントに切り出し
- evaluation-section.tsxの計算ロジックをpage.tsxに移し、props経由で渡すように変更   

#### 4月24日
- UnevaluatedStaffListを別ファイルとして切り出し

## 設計理由
**SectionEvaluationLayoutコンポーネントで全体をラップしなかった理由**
SectionEvaluationLayoutは総合評価、達成率グラフ、カテゴリレーダーチャート、カテゴリ別、セクション別達成率プログレスバーをまとめるコンポーネント。
全体をラップして統一感を出すのは良いことだが、もしグラフ同士の間隔を変更したい場合にレイアウトが崩れる恐れがある。
そのため管理者ダッシュボードのコンポーネントとは分離して配置した。

**未評価者を絞り込むためにsomeを使った理由**
staff.id !== totalEvaluations[i].idで比較するとエラーになった。理由はstaffListsとtotalEvaluationsの順序や長さが一致している保証がないため。
そこでsomeを使ってtotalEvaluationsの中にstaff.idが含まれているのかを判定し、一致しないものをfilterを使って抽出した。


**UnevaluatedStaffCardをコンポーネントにした理由**
未評価者を表示するUnevaluatedStaffCardコンポーネントだが画像表示、Linkボタンなどが含まれるためコード自体が長い。可読性向上のためコンポーネント化にしました。
コロケーションに従って定義場所は同じファイル内にした。

**evaluation-section.tsxの計算ロジックをpage.tsxへ移した理由**
ページネーションを実装した影響によりevaluation-sectionstsxはclient componentになった。
ページネーションが含まれる、unevaluatedStaffListコンポーネントは同じファイル内に記述する方針をとるのでどの道client componentになる。
しかし「計算ロジックをどこに置くべきか」という責務の分離という観点でpage.tsxにコードを移し判断となった。

**UnevaluatedStaffListコンポーネントを別ファイルにした理由**
未評価のスタッフを表示させる機能をもち、ページネーションも実装している。
役割が明確なので別ファイルへの切り出しに至った。
また、evaluation-sectionがserver componentになるのでバンドルサイズの削減にも貢献した。