### PR TITLE
Feat/add staff page

### DIFF
--- a/src/app/(protected)/admin/staff/[staffId]/page.tsx
+++ b/src/app/(protected)/admin/staff/[staffId]/page.tsx
@@ -4,10 +4,10 @@ import { createClient } from '@/lib/supabase/server';
 import { redirect } from 'next/navigation';
 import AdminContainer from '../../components/admin-contaimer';
 import { requireAdmin } from '@/lib/utils/requireAdmin';
-import StaffEvaluationSection from './components/staff-evaluation-section';
 import { ExistingEvaluation } from '../../../../../../types/evaluations';
 import { Icons } from '@/components/icon/icons';
 import { formatChartData } from '@/lib/utils/evaluation-format';
+import StaffEvaluationSection from '@/components/evaluation/staff-evaluation-section';
 
 type StaffDetailPageProps = {
   params: { staffId: string };

--- a/src/app/(protected)/staff/components/header-nav.tsx
+++ b/src/app/(protected)/staff/components/header-nav.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { Icons } from '@/components/icon/icons';
+import MobileMenu from '@/components/shared/mobile-menu';
+import { Button } from '@/components/ui/button';
+import { useAuth } from '@/hooks/use-auth';
+
+function StaffNavMobile() {
+  const { logout, isLoading } = useAuth();
+
+  return (
+    <Button
+      variant="outline"
+      className="mt-auto mb-5 w-full"
+      disabled={isLoading.logout}
+      onClick={() => logout()}
+    >
+      <Icons.LogOut className="h-5 w-5 shrink-0" />
+      ログアウト
+    </Button>
+  );
+}
+
+export default function HeaderNav() {
+  return <MobileMenu>{() => <StaffNavMobile />}</MobileMenu>;
+}

--- a/src/app/(protected)/staff/components/header.tsx
+++ b/src/app/(protected)/staff/components/header.tsx
@@ -1,0 +1,24 @@
+import MainLogo from '@/components/shared/main-logo';
+import { cn } from '@/lib/utils';
+import HeaderNav from './header-nav';
+
+type HeaderProps = {
+  className?: string;
+};
+
+export default function Header({ className }: HeaderProps) {
+  return (
+    <header
+      className={cn(
+        'fixed left-0 top-4 right-0 z-50 px-4 mx-w-[1440px]',
+        className
+      )}
+    >
+      <div className="container mx-auto px-5 sm:px-8 h-14 md:h-16 flex items-center justify-between bg-background/80 shadow-sm backdrop-blur-sm rounded-2xl border">
+        <MainLogo />
+
+        <HeaderNav />
+      </div>
+    </header>
+  );
+}

--- a/src/app/(protected)/staff/components/period-selector.tsx
+++ b/src/app/(protected)/staff/components/period-selector.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Tables } from '../../../../../types/supabase';
+import { Icons } from '@/components/icon/icons';
+import { useRouter } from 'next/navigation';
+
+//Todo: 管理者ページで同じ記述をしているのでtypes/evaluations.tsで定義して参照する
+type EvaluationPeriod = Pick<Tables<'evaluation_periods'>, 'id' | 'name'>;
+
+type PeriodSelectorProps = {
+  evaluationPeriods: EvaluationPeriod[];
+};
+
+export default function PeriodSelector({
+  evaluationPeriods,
+}: PeriodSelectorProps) {
+  const router = useRouter();
+
+  const handleValueChange = (periodId: string) => {
+    router.push(`?periodId=${periodId}`);
+  };
+  return (
+    <Select onValueChange={handleValueChange}>
+      <SelectTrigger size="default">
+        <Icons.CalendarDays className="w-4 h-4" />
+        <SelectValue placeholder="評価期間" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectGroup>
+          <SelectLabel>評価期間を選択</SelectLabel>
+          {evaluationPeriods.map((period) => (
+            <SelectItem
+              key={period.id}
+              value={period.id}
+              className="cursor-pointer"
+            >
+              {period.name}
+            </SelectItem>
+          ))}
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/app/(protected)/staff/layout.tsx
+++ b/src/app/(protected)/staff/layout.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from 'next';
+import Header from './components/header';
+
+export const metadata: Metadata = {
+  title: 'Growth Finder',
+  description: 'スタッフの成長を可視化し、関係性構築を支援する人材育成ツール',
+};
+
+export default function StaffLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <div className="min-h-screen flex flex-col md:flex-row">
+      <Header className="md:hidden" />
+      <div className="flex flex-col flex-1">
+        <main className="flex-1 p-4">{children}</main>
+        <footer className="bg-card py-4">
+          <div className="text-center text-xs text-muted-foreground">
+            <p>
+              &copy; {new Date().getFullYear()} Growth Finder. All rights
+              reserved.
+            </p>
+          </div>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(protected)/staff/layout.tsx
+++ b/src/app/(protected)/staff/layout.tsx
@@ -13,7 +13,7 @@ export default function StaffLayout({
 }>) {
   return (
     <div className="min-h-screen flex flex-col md:flex-row">
-      <Header className="md:hidden" />
+      <Header />
       <div className="flex flex-col flex-1">
         <main className="flex-1 p-4">{children}</main>
         <footer className="bg-card py-4">

--- a/src/app/(protected)/staff/page.tsx
+++ b/src/app/(protected)/staff/page.tsx
@@ -3,6 +3,9 @@ import { createClient } from '@/lib/supabase/server';
 import { requireStaff } from '@/lib/utils/requireStaff';
 import PeriodSelector from './components/period-selector';
 import { ExistingEvaluation } from '../../../../types/evaluations';
+import { formatChartData } from '@/lib/utils/evaluation-format';
+import { Icons } from '@/components/icon/icons';
+import StaffEvaluationSection from '@/components/evaluation/staff-evaluation-section';
 
 export default async function StaffPage({
   searchParams,
@@ -19,6 +22,10 @@ export default async function StaffPage({
     .select('id, name')
     .eq('organization_id', orgId);
   if (periodError || !evaluationPeriods) return;
+
+  const selectedPeriod = evaluationPeriods.find(
+    (period) => period.id === periodId
+  );
 
   const { data: targetEvaluation } = periodId
     ? ((await supabase
@@ -55,10 +62,52 @@ export default async function StaffPage({
         .single()) as { data: ExistingEvaluation | null; error: unknown })
     : { data: null };
 
+  const { data } = await supabase
+    .from('evaluation_periods')
+    .select(
+      `
+      id, name,
+      evaluations!inner (
+        evaluation_sections (
+          section_type,
+          skill_score,
+          skill_max,
+          hospitality_score,
+          hospitality_max,
+          cleanliness_score,
+          cleanliness_max
+        )
+      )
+      `
+    )
+    .eq('organization_id', orgId)
+    .eq('evaluations.staff_id', user.id)
+    .order('created_at', { ascending: true })
+    .limit(4);
+
+  const chartData = formatChartData(data ?? []);
+
   return (
     <div className="mt-20 max-w-7xl mx-auto w-full py-6 px-4 space-y-6">
       <ProfileCard profile={profile} />
       <PeriodSelector evaluationPeriods={evaluationPeriods} />
+      {!selectedPeriod ? (
+        <p className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Icons.CircleAlert />
+          評価期間が選択されていません
+        </p>
+      ) : !targetEvaluation ? (
+        <p className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Icons.CircleAlert />
+          まだ評価が登録されていません
+        </p>
+      ) : (
+        <StaffEvaluationSection
+          selectedPeriod={selectedPeriod}
+          targetEvaluation={targetEvaluation}
+          chartData={chartData}
+        />
+      )}
     </div>
   );
 }

--- a/src/app/(protected)/staff/page.tsx
+++ b/src/app/(protected)/staff/page.tsx
@@ -1,0 +1,7 @@
+export default function StaffPage() {
+  return (
+    <div>
+      <div>Staff Page</div>
+    </div>
+  );
+}

--- a/src/app/(protected)/staff/page.tsx
+++ b/src/app/(protected)/staff/page.tsx
@@ -2,22 +2,63 @@ import ProfileCard from '@/components/shared/profile-card';
 import { createClient } from '@/lib/supabase/server';
 import { requireStaff } from '@/lib/utils/requireStaff';
 import PeriodSelector from './components/period-selector';
+import { ExistingEvaluation } from '../../../../types/evaluations';
 
-export default async function StaffPage() {
+export default async function StaffPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ periodId?: string }>;
+}) {
+  const { periodId } = await searchParams;
   const supabase = await createClient();
 
-  const { profile, orgId } = await requireStaff(supabase);
+  const { profile, orgId, user } = await requireStaff(supabase);
 
-  const { data: evaluationPeriiods, error: periodError } = await supabase
+  const { data: evaluationPeriods, error: periodError } = await supabase
     .from('evaluation_periods')
     .select('id, name')
     .eq('organization_id', orgId);
-  if (periodError || !evaluationPeriiods) return;
+  if (periodError || !evaluationPeriods) return;
+
+  const { data: targetEvaluation } = periodId
+    ? ((await supabase
+        .from('evaluations')
+        .select(
+          `
+          id,
+          status,
+          action_plan,
+          total_comment,
+          future_vision,
+              evaluation_sections (
+              id,
+              section_type,
+              good_points,
+              improvement_points,
+              skill_score,
+              skill_max,
+              hospitality_score,
+              hospitality_max,
+              cleanliness_score,
+              cleanliness_max,
+                evaluation_items (
+                  item_name,
+                  category,
+                  score
+            )
+          )
+        `
+        )
+        .eq('staff_id', user.id)
+        .eq('evaluation_period_id', periodId)
+        .eq('organization_id', orgId)
+        .single()) as { data: ExistingEvaluation | null; error: unknown })
+    : { data: null };
 
   return (
     <div className="mt-20 max-w-7xl mx-auto w-full py-6 px-4 space-y-6">
       <ProfileCard profile={profile} />
-      <PeriodSelector evaluationPeriods={evaluationPeriiods} />
+      <PeriodSelector evaluationPeriods={evaluationPeriods} />
     </div>
   );
 }

--- a/src/app/(protected)/staff/page.tsx
+++ b/src/app/(protected)/staff/page.tsx
@@ -1,4 +1,13 @@
-export default function StaffPage() {
+import { createClient } from '@/lib/supabase/server';
+import { requireStaff } from '@/lib/utils/requireStaff';
+
+export default async function StaffPage() {
+  const supabase = await createClient();
+
+  const { orgId, profile } = await requireStaff(supabase);
+
+  console.log(orgId, profile);
+
   return (
     <div>
       <div>Staff Page</div>

--- a/src/app/(protected)/staff/page.tsx
+++ b/src/app/(protected)/staff/page.tsx
@@ -1,16 +1,15 @@
+import ProfileCard from '@/components/shared/profile-card';
 import { createClient } from '@/lib/supabase/server';
 import { requireStaff } from '@/lib/utils/requireStaff';
 
 export default async function StaffPage() {
   const supabase = await createClient();
 
-  const { orgId, profile } = await requireStaff(supabase);
-
-  console.log(orgId, profile);
+  const { profile } = await requireStaff(supabase);
 
   return (
-    <div>
-      <div>Staff Page</div>
+    <div className="mt-20 max-w-7xl mx-auto w-full py-6 px-4 space-y-6">
+      <ProfileCard profile={profile} />
     </div>
   );
 }

--- a/src/app/(protected)/staff/page.tsx
+++ b/src/app/(protected)/staff/page.tsx
@@ -6,6 +6,7 @@ import { ExistingEvaluation } from '../../../../types/evaluations';
 import { formatChartData } from '@/lib/utils/evaluation-format';
 import { Icons } from '@/components/icon/icons';
 import StaffEvaluationSection from '@/components/evaluation/staff-evaluation-section';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
 export default async function StaffPage({
   searchParams,
@@ -90,7 +91,17 @@ export default async function StaffPage({
   return (
     <div className="mt-20 max-w-7xl mx-auto w-full py-6 px-4 space-y-6">
       <ProfileCard profile={profile} />
-      <PeriodSelector evaluationPeriods={evaluationPeriods} />
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex gap-2">
+            <Icons.MousePointer className="w-5 h-5" />
+            評価期間を選択
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <PeriodSelector evaluationPeriods={evaluationPeriods} />
+        </CardContent>
+      </Card>
       {!selectedPeriod ? (
         <p className="flex items-center gap-2 text-sm text-muted-foreground">
           <Icons.CircleAlert />

--- a/src/app/(protected)/staff/page.tsx
+++ b/src/app/(protected)/staff/page.tsx
@@ -1,15 +1,23 @@
 import ProfileCard from '@/components/shared/profile-card';
 import { createClient } from '@/lib/supabase/server';
 import { requireStaff } from '@/lib/utils/requireStaff';
+import PeriodSelector from './components/period-selector';
 
 export default async function StaffPage() {
   const supabase = await createClient();
 
-  const { profile } = await requireStaff(supabase);
+  const { profile, orgId } = await requireStaff(supabase);
+
+  const { data: evaluationPeriiods, error: periodError } = await supabase
+    .from('evaluation_periods')
+    .select('id, name')
+    .eq('organization_id', orgId);
+  if (periodError || !evaluationPeriiods) return;
 
   return (
     <div className="mt-20 max-w-7xl mx-auto w-full py-6 px-4 space-y-6">
       <ProfileCard profile={profile} />
+      <PeriodSelector evaluationPeriods={evaluationPeriiods} />
     </div>
   );
 }

--- a/src/components/evaluation/overall-evaluation.tsx
+++ b/src/components/evaluation/overall-evaluation.tsx
@@ -1,9 +1,5 @@
 import { calcEvaluation } from '@/lib/utils/evaluation-calc';
 import {
-  ChartDataPoint,
-  ExistingEvaluation,
-} from '../../../../../../../types/evaluations';
-import {
   formatCategoryRates,
   formatSectionRates,
 } from '@/lib/utils/evaluation-format';
@@ -11,6 +7,7 @@ import EvaluationLineChart from '@/components/evaluation/evaluation-line-chart';
 import SummaryComments from '@/components/evaluation/summary-comments';
 import SectionEvaluationDetail from '@/components/evaluation/section-evaluation-detail';
 import SectionEvaluationLayout from '@/components/evaluation/section-evaluation-layout';
+import { ChartDataPoint, ExistingEvaluation } from '../../../types/evaluations';
 
 type OverallEvaluationProps = {
   targetEvaluation: ExistingEvaluation;

--- a/src/components/evaluation/section-evaluation-content.tsx
+++ b/src/components/evaluation/section-evaluation-content.tsx
@@ -1,8 +1,3 @@
-import {
-  EvaluationItem,
-  ExistingEvaluation,
-  SectionType,
-} from '../../../../../../../types/evaluations';
 import { calcEvaluation } from '@/lib/utils/evaluation-calc';
 import SectionEvaluationDetail from '@/components/evaluation/section-evaluation-detail';
 import { formatCategoryRates } from '@/lib/utils/evaluation-format';
@@ -10,6 +5,11 @@ import SectionEvaluationLayout from '@/components/evaluation/section-evaluation-
 import SectionTab from '@/components/evaluation/section-tab';
 import { SECTION_ITEMS } from '@/lib/constants/evaluation-items';
 import { getSectionStats } from '@/lib/utils/evaluation-utils';
+import {
+  EvaluationItem,
+  ExistingEvaluation,
+  SectionType,
+} from '../../../types/evaluations';
 
 type SectionEvaluationContentProps = {
   targetEvaluation: ExistingEvaluation;

--- a/src/components/evaluation/staff-evaluation-section.tsx
+++ b/src/components/evaluation/staff-evaluation-section.tsx
@@ -1,13 +1,7 @@
 'use client';
 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Tables } from '../../../../../../../types/supabase';
 import { Icons } from '@/components/icon/icons';
-import {
-  ChartDataPoint,
-  ExistingEvaluation,
-  SectionType,
-} from '../../../../../../../types/evaluations';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import OverallEvaluation from './overall-evaluation';
 import { useState } from 'react';
@@ -16,6 +10,12 @@ import {
   isSectionType,
 } from '@/lib/utils/evaluation-utils';
 import SectionEvaluationContent from './section-evaluation-content';
+import { Tables } from '../../../types/supabase';
+import {
+  ChartDataPoint,
+  ExistingEvaluation,
+  SectionType,
+} from '../../../types/evaluations';
 
 type EvaluationPeriod = Pick<Tables<'evaluation_periods'>, 'id' | 'name'>;
 

--- a/src/components/icon/icons.tsx
+++ b/src/components/icon/icons.tsx
@@ -37,6 +37,7 @@ import {
   ArrowBigRight,
   ChevronLeft,
   ChevronRight,
+  MousePointer,
 } from 'lucide-react';
 
 import { FaXTwitter, FaGithub } from 'react-icons/fa6';
@@ -89,6 +90,7 @@ export const Icons = {
   ArrowBigRight,
   ChevronLeft,
   ChevronRight,
+  MousePointer,
   FaXTwitter,
   FaGithub,
   FcGoogle,

--- a/src/lib/utils/requireStaff.ts
+++ b/src/lib/utils/requireStaff.ts
@@ -1,0 +1,26 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+import { Database } from '../../../types/supabase';
+
+export async function requireStaff(supabase: SupabaseClient<Database>) {
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+  if (authError || !user) throw new Error('認証エラーが発生しました');
+
+  const { data: profile, error: profileError } = await supabase
+    .from('profiles')
+    .select('store_name, role, organization_id, email, avatar_url, name')
+    .eq('id', user.id)
+    .single();
+
+  if (profileError) throw new Error('プロフィールの取得に失敗しました');
+
+  if (!profile || profile.role !== 'staff' || !profile.organization_id) {
+    throw new Error('この操作を行う権限または、組織設定がありません');
+  }
+
+  const orgId = profile.organization_id;
+
+  return { user, profile, orgId };
+}


### PR DESCRIPTION
## 概要
スタッフページの実装

## 対応
### 4月24日
- ヘッダーを実装
- 権限をチェックするヘルパー関数を実装
- スタッフプロフィールカードを実装
- 評価期間を切り替えるセレクタを実装
- peirodIdでデータを絞り込みsupabaseから取得

### 4月25日
- スタッフページに詳細評価を追加
- 評価期間選択セクションを追加

## 設計理由

**サイドバーをなくした理由**
管理者ページと同じデザインの想定だったがスタッフページのナビゲーションメニューはログアウトボタンのみ。
サイドバーは過剰なUIなのでヘッダーのみに変更した。

**評価期間をクエリストリングから取得した理由**
スタッフは任意に過去の評価を遡って閲覧することができる想定。
従って評価期間をすべてSelectで選択できるようにして、onValueChangeで選択したvalueを受け取りクエリストリングに埋め込む方針にした。
useStateでの管理はURLに状態が残らないのでページリロードで選択がリセットされるので却下。
DBのフラグを更新する方法もあったがスタッフ個人の閲覧中の期間をDBに保存するのは過剰と判断し却下。

**staff-evaluation-section.tsxをsrc/componentsに移動した理由**
管理者のスタッフ詳細ページで使用していたコンポーネントがスタッフページでも
そのまま再利用できると判断したため、src/components/evaluationに移動して
両方から参照できるようにした。
