### PR TITLE
fix: React Compiler警告の解消のためwatch関数をuseWatchに置き換え

### DIFF
--- a/src/app/(protected)/admin/staff/[staffId]/evaluation/components/evaluation-form.tsx
+++ b/src/app/(protected)/admin/staff/[staffId]/evaluation/components/evaluation-form.tsx
@@ -17,7 +17,7 @@ import {
   FormattedEvaluation,
 } from '../../../../../../../../types/evaluations';
 import EvaluationComments from './evaluation-comments';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { EvaluationInput, evaluationSchema } from '@/lib/validations/schemas';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { toast } from 'sonner';
@@ -75,6 +75,7 @@ export default function EvaluationForm({
     register,
     setValue,
     watch,
+    control,
     handleSubmit,
     formState: { isSubmitting },
   } = useForm<EvaluationInput>({
@@ -114,12 +115,14 @@ export default function EvaluationForm({
         },
   });
 
+  const formValues = useWatch({ control });
+
   const countScoredItems = () => {
     let result = 0;
 
     for (const section of SECTION_TYPES) {
       for (const category of CATEGORIES) {
-        result += Object.keys(watch(`${section}.${category}`)).length;
+        result += Object.keys(formValues[section]?.[category] ?? {}).length;
       }
     }
     return result;
@@ -146,9 +149,8 @@ export default function EvaluationForm({
   };
 
   const saveDraftEvaluations = async () => {
-    const draftEvaluations = watch();
     try {
-      await saveDraft(draftEvaluations, staffId, periodId);
+      await saveDraft(formValues as EvaluationInput, staffId, periodId);
       toast.success('評価を下書き保存しました');
     } catch (error) {
       toast.error('評価の下書きに失敗しました', {


### PR DESCRIPTION
## 概要
evaluation-form.tsxでReact Hook FormのwatchをReact Compilerがメモ化できないという警告の修正

## 対応
- countScoredItemsとsaveDraftEvaluationsでwatch()を使用していたため警告が発生
- useWatch({ control })でフォーム全体を監視してwatch関数の代替とした

## 設計理由
evaluation-form.tsx内のcountScoredItemsとsaveDraftEvaluationsでwatch()を使用していたのが警告の原因だった。
watch()はReactのレンダリングサイクルの外で動作しているので関数がいつ新しい値を返すか分からないためメモ化できないと警告。
代替手段としてuseWatch()を選択した。
理由はuseWatch()はReactのレンダリングサイクル内で管理されているのでメモ化ができるので採用した。

Closes #102