### PR TITLE
Feat/add demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# supabase
+supabase/snippets/

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "eslint": "^9",
         "eslint-config-next": "16.1.5",
         "tailwindcss": "^4",
+        "tsx": "^4.21.0",
         "tw-animate-css": "^1.4.0",
         "typescript": "^5"
       }
@@ -324,6 +325,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -5118,6 +5561,48 @@
         "benchmarks"
       ]
     },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -5710,6 +6195,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -8615,6 +9115,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tw-animate-css": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint": "^9",
     "eslint-config-next": "16.1.5",
     "tailwindcss": "^4",
+    "tsx": "^4.21.0",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5"
   }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "generate-seed": "tsx scripts/generate-seed.ts",
     "typecheck": "tsc --noEmit",
     "check": "npm run lint && npm run typecheck",
     "db:types": "supabase gen types typescript --local > types/supabase.ts",

--- a/scripts/generate-seed.ts
+++ b/scripts/generate-seed.ts
@@ -1,0 +1,55 @@
+import { SECTION_ITEMS } from '../src/lib/constants/evaluation-items';
+
+type SectionType = 'basic' | 'barista' | 'cashier';
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111';
+
+const SECTION_IDS: Record<string, Record<SectionType, string>> = {
+  staffA: {
+    basic: 'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
+    barista: 'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
+    cashier: 'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
+  },
+  staffB: {
+    basic: 'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
+    barista: 'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
+    cashier: 'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
+  },
+};
+
+const generateSeed = (sectionId: string, sectionType: SectionType): string => {
+  let sql = '';
+  const categories = ['skill', 'hospitality', 'cleanliness'] as const;
+
+  for (const category of categories) {
+    const items = SECTION_ITEMS[sectionType][category];
+    for (const item of items) {
+      sql += `
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '${ORG_ID}',
+  '${sectionId}',
+  '${item.item_name}',
+  '${category}',
+  3
+);\n`;
+    }
+  }
+
+  return sql;
+};
+
+console.log(generateSeed(SECTION_IDS.staffA.basic, 'basic'));
+console.log(generateSeed(SECTION_IDS.staffA.cashier, 'cashier'));
+console.log(generateSeed(SECTION_IDS.staffA.barista, 'barista'));
+
+console.log(generateSeed(SECTION_IDS.staffB.basic, 'basic'));
+console.log(generateSeed(SECTION_IDS.staffB.cashier, 'cashier'));
+console.log(generateSeed(SECTION_IDS.staffB.barista, 'barista'));

--- a/scripts/generate-seed.ts
+++ b/scripts/generate-seed.ts
@@ -24,6 +24,11 @@ const generateSeed = (sectionId: string, sectionType: SectionType): string => {
   for (const category of categories) {
     const items = SECTION_ITEMS[sectionType][category];
     for (const item of items) {
+      const checkPointSql = item.check_points
+        ? `ARRAY[${item.check_points
+            .map((p) => `'${p.replace(/'/g, "''")}'`)
+            .join(', ')}]`
+        : `ARRAY[]::text[]`;
       sql += `
 INSERT INTO evaluation_items (
   id,
@@ -31,14 +36,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '${ORG_ID}',
   '${sectionId}',
   '${item.item_name}',
   '${category}',
-  3
+  3,
+  ${checkPointSql}
 );\n`;
     }
   }

--- a/src/app/(protected)/admin/layout.tsx
+++ b/src/app/(protected)/admin/layout.tsx
@@ -2,24 +2,33 @@ import type { Metadata } from 'next';
 
 import Header from './components/header';
 import Sidebar from './components/sidebar';
+import { createClient } from '@/lib/supabase/server';
+import { requireAdmin } from '@/lib/utils/requireAdmin';
+import DemoBanner from '@/components/shared/demo-banner';
 
 export const metadata: Metadata = {
   title: 'Growth Finder',
   description: 'スタッフの成長を可視化し、関係性構築を支援する人材育成ツール',
 };
 
-export default function AdminLayout({
+export default async function AdminLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const supabase = await createClient();
+  const { profile } = await requireAdmin(supabase);
+
   return (
     <div className="min-h-screen flex flex-col md:flex-row">
       <Header className="md:hidden" />
 
       <Sidebar className="hidden md:flex" />
       <div className="flex flex-col flex-1">
-        <main className="flex-1 p-4">{children}</main>
+        <main className="flex-1 p-4">
+          <DemoBanner isDemo={profile.is_demo ?? false} />
+          {children}
+        </main>
         <footer className="bg-card py-4">
           <div className="text-center text-xs text-muted-foreground">
             <p>

--- a/src/app/(protected)/admin/setting/page.tsx
+++ b/src/app/(protected)/admin/setting/page.tsx
@@ -6,6 +6,7 @@ import { createClient } from '@/lib/supabase/server';
 import BackPageLink from '@/components/shared/back-page-link';
 import AdminContainer from '../components/admin-contaimer';
 import { requireAdmin } from '@/lib/utils/requireAdmin';
+import DemoRestricted from '@/components/shared/demo-restricted';
 
 export default async function SettingPage() {
   const supabase = await createClient();
@@ -26,7 +27,9 @@ export default async function SettingPage() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <SettingForm profile={profile} />
+            <DemoRestricted isDemo={profile.is_demo ?? false}>
+              <SettingForm profile={profile} />
+            </DemoRestricted>
           </CardContent>
         </Card>
 
@@ -38,7 +41,9 @@ export default async function SettingPage() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <PasswordForm isOAuthUser={isOAuthUser} />
+            <DemoRestricted isDemo={profile.is_demo ?? false}>
+              <PasswordForm isOAuthUser={isOAuthUser} />
+            </DemoRestricted>
           </CardContent>
         </Card>
       </div>

--- a/src/app/(protected)/admin/staff/[staffId]/page.tsx
+++ b/src/app/(protected)/admin/staff/[staffId]/page.tsx
@@ -20,7 +20,7 @@ export default async function StaffDetailPage({
 
   const supabase = await createClient();
 
-  const { orgId } = await requireAdmin(supabase);
+  const { orgId, profile } = await requireAdmin(supabase);
 
   const { data: targetStaff, error: targetStaffError } = await supabase
     .from('profiles')
@@ -101,7 +101,11 @@ export default async function StaffDetailPage({
   return (
     <AdminContainer>
       <BackPageLink href="/admin/staff" label="スタッフ一覧に戻る" />
-      <StaffProfile targetStaff={targetStaff} staffId={staffId} />
+      <StaffProfile
+        isDemo={profile.is_demo ?? false}
+        targetStaff={targetStaff}
+        staffId={staffId}
+      />
       {!selectedPeriod ? (
         <p className="flex items-center gap-2 text-sm text-muted-foreground">
           <Icons.CircleAlert />

--- a/src/app/(protected)/admin/staff/components/staff-card-menu.tsx
+++ b/src/app/(protected)/admin/staff/components/staff-card-menu.tsx
@@ -418,13 +418,23 @@ export default function StaffCardMenu({
               パスワード変更
             </DropdownMenuItem>
           )}
-          <DropdownMenuItem
-            onSelect={() => setIsDeleteOpen(true)}
-            className="cursor-pointer text-destructive"
-          >
-            <Icons.Trash2 className="mr-2 size-4" />
-            削除
-          </DropdownMenuItem>
+          {isDemo ? (
+            <DropdownMenuItem
+              disabled
+              className="cursor-not-allowed text-muted-foreground"
+            >
+              <Icons.Trash2 className="mr-2 size-4" />
+              削除（デモモードのため不可）
+            </DropdownMenuItem>
+          ) : (
+            <DropdownMenuItem
+              onSelect={() => setIsDeleteOpen(true)}
+              className="cursor-pointer text-destructive"
+            >
+              <Icons.Trash2 className="mr-2 size-4" />
+              削除
+            </DropdownMenuItem>
+          )}
         </DropdownMenuContent>
       </DropdownMenu>
 

--- a/src/app/(protected)/admin/staff/components/staff-card-menu.tsx
+++ b/src/app/(protected)/admin/staff/components/staff-card-menu.tsx
@@ -49,10 +49,12 @@ import {
 import { uploadStaffAvatar } from '@/lib/utils/upload';
 import Link from 'next/link';
 import { Tables } from '../../../../../../types/supabase';
+import DemoRestricted from '@/components/shared/demo-restricted';
 
 type EvaluationPeriod = Pick<Tables<'evaluation_periods'>, 'id'> | null;
 
 type StaffCardMenuProps = {
+  isDemo: boolean;
   staff: Staff;
   selectedPeriod: EvaluationPeriod;
 };
@@ -342,6 +344,7 @@ function EditPasswordDialog({
 }
 
 export default function StaffCardMenu({
+  isDemo,
   staff,
   selectedPeriod,
 }: StaffCardMenuProps) {
@@ -379,20 +382,42 @@ export default function StaffCardMenu({
               評価(期間未選択)
             </DropdownMenuItem>
           )}
-          <DropdownMenuItem
-            className="cursor-pointer"
-            onSelect={() => setIsEditOpen(true)}
-          >
-            <Icons.Pencil className="mr-2 size-4" />
-            編集
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            className="cursor-pointer"
-            onSelect={() => setIsEditPasswordOpen(true)}
-          >
-            <Icons.KeyRound className="mr-2 size-4" />
-            パスワード変更
-          </DropdownMenuItem>
+
+          {isDemo ? (
+            <DropdownMenuItem
+              disabled
+              className="cursor-not-allowed text-muted-foreground"
+            >
+              <Icons.Pencil className="mr-2 size-4" />
+              編集（デモモードのため不可）
+            </DropdownMenuItem>
+          ) : (
+            <DropdownMenuItem
+              className="cursor-pointer"
+              onSelect={() => setIsEditOpen(true)}
+            >
+              <Icons.Pencil className="mr-2 size-4" />
+              編集
+            </DropdownMenuItem>
+          )}
+
+          {isDemo ? (
+            <DropdownMenuItem
+              disabled
+              className="cursor-not-allowed text-muted-foreground"
+            >
+              <Icons.KeyRound className="mr-2 size-4" />
+              パスワード変更(デモモードのため不可)
+            </DropdownMenuItem>
+          ) : (
+            <DropdownMenuItem
+              className="cursor-pointer"
+              onSelect={() => setIsEditPasswordOpen(true)}
+            >
+              <Icons.KeyRound className="mr-2 size-4" />
+              パスワード変更
+            </DropdownMenuItem>
+          )}
           <DropdownMenuItem
             onSelect={() => setIsDeleteOpen(true)}
             className="cursor-pointer text-destructive"

--- a/src/app/(protected)/admin/staff/components/staff-card.tsx
+++ b/src/app/(protected)/admin/staff/components/staff-card.tsx
@@ -11,12 +11,14 @@ import { calcEvaluation } from '@/lib/utils/evaluation-calc';
 type EvaluationPeriod = Pick<Tables<'evaluation_periods'>, 'id'> | null;
 
 type StaffCardProps = {
+  isDemo: boolean;
   staff: Staff;
   selectedPeriod: EvaluationPeriod;
   staffEvaluation: ExistingEvaluationForStaffCard | undefined;
 };
 
 export default function StaffCard({
+  isDemo,
   staff,
   selectedPeriod,
   staffEvaluation,
@@ -29,7 +31,11 @@ export default function StaffCard({
     <Card className="relative">
       <CardContent className="pb-4">
         <div className="absolute top-3 right-3">
-          <StaffCardMenu staff={staff} selectedPeriod={selectedPeriod} />
+          <StaffCardMenu
+            isDemo={isDemo}
+            staff={staff}
+            selectedPeriod={selectedPeriod}
+          />
         </div>
 
         <div className="flex justify-center items-center">

--- a/src/app/(protected)/admin/staff/components/staff-list.tsx
+++ b/src/app/(protected)/admin/staff/components/staff-list.tsx
@@ -10,12 +10,14 @@ import { ExistingEvaluationForStaffCard } from '../../../../../../types/evaluati
 type EvaluationPeriod = Pick<Tables<'evaluation_periods'>, 'id'> | null;
 
 type StaffListProps = {
+  isDemo: boolean;
   staffs: Staff[];
   selectedPeriod: EvaluationPeriod;
   existingEvaluations: ExistingEvaluationForStaffCard[];
 };
 
 export default function StaffList({
+  isDemo,
   staffs,
   selectedPeriod,
   existingEvaluations,
@@ -44,6 +46,7 @@ export default function StaffList({
               );
               return (
                 <StaffCard
+                  isDemo={isDemo}
                   key={staff.id}
                   staff={staff}
                   selectedPeriod={selectedPeriod}

--- a/src/app/(protected)/admin/staff/components/staff-profile.tsx
+++ b/src/app/(protected)/admin/staff/components/staff-profile.tsx
@@ -29,11 +29,16 @@ type Profile = Pick<
 >;
 
 type StaffProfile = {
+  isDemo: boolean;
   targetStaff: Profile;
   staffId: string;
 };
 
-export default function StaffProfile({ targetStaff, staffId }: StaffProfile) {
+export default function StaffProfile({
+  isDemo,
+  targetStaff,
+  staffId,
+}: StaffProfile) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [avatarUrl, setAvatarUrl] = useState<string | null>(
     targetStaff.avatar_url
@@ -123,14 +128,16 @@ export default function StaffProfile({ targetStaff, staffId }: StaffProfile) {
                       <Icons.UserCircle className="w-16 h-16 text-muted-foreground" />
                     )}
                   </div>
-                  <button
-                    type="button"
-                    disabled={isUploading}
-                    onClick={() => fileInputRef.current?.click()}
-                    className="absolute bottom-0 right-0 bg-background border rounded-full px-2 py-0.5 text-xs"
-                  >
-                    編集
-                  </button>
+                  {!isDemo && (
+                    <button
+                      type="button"
+                      disabled={isUploading}
+                      onClick={() => fileInputRef.current?.click()}
+                      className="absolute bottom-0 right-0 bg-background border rounded-full px-2 py-0.5 text-xs"
+                    >
+                      編集
+                    </button>
+                  )}
                   <input
                     type="file"
                     ref={fileInputRef}
@@ -157,31 +164,50 @@ export default function StaffProfile({ targetStaff, staffId }: StaffProfile) {
               </div>
             </div>
 
-            <div className="space-y-2 w-full max-w-md">
-              <Label htmlFor="name">名前</Label>
-              <Input id="name" type="text" {...register('name')} />
-              {errors.name && (
-                <p className="text-sm text-red-500">{errors.name?.message}</p>
-              )}
-            </div>
-            <div className="space-y-2 w-full max-w-md">
-              <Label htmlFor="email">メールアドレス</Label>
-              <Input id="email" type="email" {...register('email')} />
-              {errors.email && (
-                <p className="text-sm text-red-500">{errors.email?.message}</p>
-              )}
-            </div>
+            {isDemo ? (
+              <div className="space-y-4 w-full max-w-md">
+                <div className="space-y-2">
+                  <Label>名前</Label>
+                  <Input value={targetStaff.name ?? ''} disabled readOnly />
+                </div>
+                <div className="space-y-2">
+                  <Label>メールアドレス</Label>
+                  <Input value={targetStaff.email ?? ''} disabled readOnly />
+                </div>
+              </div>
+            ) : (
+              <>
+                <div className="space-y-2 w-full max-w-md">
+                  <Label htmlFor="name">名前</Label>
+                  <Input id="name" type="text" {...register('name')} />
+                  {errors.name && (
+                    <p className="text-sm text-red-500">
+                      {errors.name?.message}
+                    </p>
+                  )}
+                </div>
+                <div className="space-y-2 w-full max-w-md">
+                  <Label htmlFor="email">メールアドレス</Label>
+                  <Input id="email" type="email" {...register('email')} />
+                  {errors.email && (
+                    <p className="text-sm text-red-500">
+                      {errors.email?.message}
+                    </p>
+                  )}
+                </div>
 
-            <div className="text-center w-full max-w-md">
-              <Button
-                type="submit"
-                size="lg"
-                disabled={isSubmitting}
-                className="w-full md:max-w-48"
-              >
-                {isSubmitting ? <LoaderCircleIcon /> : '保存'}
-              </Button>
-            </div>
+                <div className="text-center w-full max-w-md">
+                  <Button
+                    type="submit"
+                    size="lg"
+                    disabled={isSubmitting}
+                    className="w-full md:max-w-48"
+                  >
+                    {isSubmitting ? <LoaderCircleIcon /> : '保存'}
+                  </Button>
+                </div>
+              </>
+            )}
           </div>
         </form>
       </CardContent>

--- a/src/app/(protected)/admin/staff/page.tsx
+++ b/src/app/(protected)/admin/staff/page.tsx
@@ -12,7 +12,7 @@ import { ExistingEvaluationForStaffCard } from '../../../../../types/evaluations
 export default async function StaffManagementPage() {
   const supabase = await createClient();
 
-  const { orgId } = await requireAdmin(supabase);
+  const { orgId, profile } = await requireAdmin(supabase);
 
   const { data: staffs, error: staffsError } = await supabase
     .from('profiles')
@@ -74,6 +74,7 @@ export default async function StaffManagementPage() {
 
         <CardContent className="space-y-6">
           <StaffList
+            isDemo={profile.is_demo ?? false}
             staffs={staffs ?? []}
             selectedPeriod={selectedPeriod}
             existingEvaluations={existingEvaluations ?? []}

--- a/src/app/demo/page.tsx
+++ b/src/app/demo/page.tsx
@@ -1,0 +1,13 @@
+import { createClient } from '@/lib/supabase/server';
+import { redirect } from 'next/navigation';
+
+export default async function DemoPage() {
+  const supabase = await createClient();
+
+  await supabase.auth.signInWithPassword({
+    email: process.env.DEMO_EMAIL!,
+    password: process.env.DEMO_PASSWORD!,
+  });
+
+  redirect('/admin');
+}

--- a/src/app/demo/route.ts
+++ b/src/app/demo/route.ts
@@ -1,7 +1,7 @@
 import { createClient } from '@/lib/supabase/server';
-import { redirect } from 'next/navigation';
+import { NextResponse } from 'next/server';
 
-export default async function DemoPage() {
+export async function GET() {
   const supabase = await createClient();
 
   await supabase.auth.signInWithPassword({
@@ -9,5 +9,7 @@ export default async function DemoPage() {
     password: process.env.DEMO_PASSWORD!,
   });
 
-  redirect('/admin');
+  return NextResponse.redirect(
+    new URL('/admin', process.env.NEXT_PUBLIC_SITE_URL!)
+  );
 }

--- a/src/components/icon/icons.tsx
+++ b/src/components/icon/icons.tsx
@@ -38,6 +38,7 @@ import {
   ChevronLeft,
   ChevronRight,
   MousePointer,
+  TriangleAlert,
 } from 'lucide-react';
 
 import { FaXTwitter, FaGithub } from 'react-icons/fa6';
@@ -91,6 +92,7 @@ export const Icons = {
   ChevronLeft,
   ChevronRight,
   MousePointer,
+  TriangleAlert,
   FaXTwitter,
   FaGithub,
   FcGoogle,

--- a/src/components/shared/demo-banner.tsx
+++ b/src/components/shared/demo-banner.tsx
@@ -7,11 +7,11 @@ type DemoBannerProps = {
 export default function DemoBanner({ isDemo }: DemoBannerProps) {
   if (!isDemo) return null;
 
-  return (  
+  return (
     <div className="max-w-7xl mx-auto sticky top-20 sm:top-5 z-50 px-4">
       <div className="flex items-center gap-2 justify-center bg-yellow-400 text-yellow-900 text-sm rounded-3xl p-2">
         <Icons.TriangleAlert />
-        デモモードで閲覧中です。
+        デモモードで閲覧中です
       </div>
     </div>
   );

--- a/src/components/shared/demo-banner.tsx
+++ b/src/components/shared/demo-banner.tsx
@@ -1,0 +1,18 @@
+import { Icons } from '../icon/icons';
+
+type DemoBannerProps = {
+  isDemo: boolean;
+};
+
+export default function DemoBanner({ isDemo }: DemoBannerProps) {
+  if (!isDemo) return null;
+
+  return (  
+    <div className="max-w-7xl mx-auto sticky top-20 sm:top-5 z-50 px-4">
+      <div className="flex items-center gap-2 justify-center bg-yellow-400 text-yellow-900 text-sm rounded-3xl p-2">
+        <Icons.TriangleAlert />
+        デモモードで閲覧中です。
+      </div>
+    </div>
+  );
+}

--- a/src/components/shared/demo-restricted.tsx
+++ b/src/components/shared/demo-restricted.tsx
@@ -1,0 +1,17 @@
+type DemoRestrictedProps = {
+  isDemo: boolean;
+  children: React.ReactNode;
+};
+
+export default function DemoRestricted({
+  isDemo,
+  children,
+}: DemoRestrictedProps) {
+  if (isDemo)
+    return (
+      <p className="text-muted-foreground text-sm">
+        デモモードのため編集できません
+      </p>
+    );
+  return children;
+}

--- a/src/lib/utils/requireAdmin.ts
+++ b/src/lib/utils/requireAdmin.ts
@@ -10,7 +10,9 @@ export async function requireAdmin(supabase: SupabaseClient<Database>) {
 
   const { data: profile, error: profileError } = await supabase
     .from('profiles')
-    .select('store_name, role, organization_id, email, avatar_url, name')
+    .select(
+      'store_name, role, organization_id, email, avatar_url, name, is_demo'
+    )
     .eq('id', user.id)
     .single();
 

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -452,3 +452,1772 @@ INSERT INTO evaluation_sections (
   21,
   28
 );
+> growth-finder@0.1.0 generate-seed
+> tsx scripts/generate-seed.ts
+
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
+  '経営理念に沿った行動',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
+  '出退勤ができる',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
+  'シフトを期限内に提出できる',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
+  '早退、欠勤の連絡ができる',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
+  '自店舗の正しい情報',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
+  '守秘義務を理解し守っている',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
+  'シフトインのときのコーヒーテイスティング',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
+  '電話番号対応ができる',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
+  'アレルギー対応',
+  'hospitality',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
+  '接客用語に間違いは無いか',
+  'hospitality',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
+  'クレーム対応',
+  'hospitality',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
+  '従業員同士の声掛け',
+  'hospitality',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
+  '仲間とのやり取り',
+  'hospitality',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
+  'ドレスコードを遵守している',
+  'cleanliness',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
+  '正しい手洗いができる',
+  'cleanliness',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
+  '店内環境の整備',
+  'cleanliness',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
+  '腸内検査は毎回提出している',
+  'cleanliness',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
+  '厨房内は走らない',
+  'cleanliness',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
+  '周囲の安全確認',
+  'cleanliness',
+  3
+);
+
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
+  'POSレジの基本動作',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
+  '現金での決済ができる',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
+  'キャッシュレス決済ができる',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
+  '領収書の発行',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
+  '商品券の取扱い',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
+  '感じの良いあいさつ',
+  'hospitality',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
+  '感じの良い話し方',
+  'hospitality',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
+  '立ち振舞い',
+  'hospitality',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
+  '心のこもった感謝の言葉',
+  'hospitality',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
+  'お客様に沿ったおすすめ',
+  'hospitality',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
+  'バリスタとの連携',
+  'hospitality',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
+  'ショーケース内の整理整頓',
+  'cleanliness',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
+  'POSレジ周りの整理整頓',
+  'cleanliness',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
+  'POSレジ周りの清掃',
+  'cleanliness',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
+  '提供時の消費期限の確認',
+  'cleanliness',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
+  '異物混入に対しての意識',
+  'cleanliness',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
+  '動線、転倒防止への配慮',
+  'cleanliness',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
+  'お客様情報の保護',
+  'cleanliness',
+  3
+);
+
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
+  'ラテ作成/ドージング',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
+  'ラテ作成/タンピング',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
+  'ラテ作成/エスプレッソ抽出',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
+  'ラテ作成/適切なスチーミング',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
+  'ラテ作成/スチームミルクの仕上がり',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
+  'ラテ作成/見た目',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
+  '商品を正しい順番で作成できている',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
+  '全商品を作成できる',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
+  '機械の操作ができる',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
+  '立ち振舞い',
+  'hospitality',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
+  '感じの良い提供',
+  'hospitality',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
+  'お見送り',
+  'hospitality',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
+  '声掛け',
+  'hospitality',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
+  '強力したオペレーション',
+  'hospitality',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
+  '消費期限の確認',
+  'cleanliness',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
+  '作業台の清潔さ',
+  'cleanliness',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
+  '顔、髪に触れていない',
+  'cleanliness',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
+  '異物混入への意識',
+  'cleanliness',
+  3
+);
+
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
+  '経営理念に沿った行動',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
+  '出退勤ができる',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
+  'シフトを期限内に提出できる',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
+  '早退、欠勤の連絡ができる',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
+  '自店舗の正しい情報',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
+  '守秘義務を理解し守っている',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
+  'シフトインのときのコーヒーテイスティング',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
+  '電話番号対応ができる',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
+  'アレルギー対応',
+  'hospitality',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
+  '接客用語に間違いは無いか',
+  'hospitality',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
+  'クレーム対応',
+  'hospitality',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
+  '従業員同士の声掛け',
+  'hospitality',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
+  '仲間とのやり取り',
+  'hospitality',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
+  'ドレスコードを遵守している',
+  'cleanliness',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
+  '正しい手洗いができる',
+  'cleanliness',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
+  '店内環境の整備',
+  'cleanliness',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
+  '腸内検査は毎回提出している',
+  'cleanliness',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
+  '厨房内は走らない',
+  'cleanliness',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
+  '周囲の安全確認',
+  'cleanliness',
+  3
+);
+
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
+  'POSレジの基本動作',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
+  '現金での決済ができる',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
+  'キャッシュレス決済ができる',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
+  '領収書の発行',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
+  '商品券の取扱い',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
+  '感じの良いあいさつ',
+  'hospitality',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
+  '感じの良い話し方',
+  'hospitality',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
+  '立ち振舞い',
+  'hospitality',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
+  '心のこもった感謝の言葉',
+  'hospitality',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
+  'お客様に沿ったおすすめ',
+  'hospitality',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
+  'バリスタとの連携',
+  'hospitality',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
+  'ショーケース内の整理整頓',
+  'cleanliness',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
+  'POSレジ周りの整理整頓',
+  'cleanliness',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
+  'POSレジ周りの清掃',
+  'cleanliness',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
+  '提供時の消費期限の確認',
+  'cleanliness',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
+  '異物混入に対しての意識',
+  'cleanliness',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
+  '動線、転倒防止への配慮',
+  'cleanliness',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
+  'お客様情報の保護',
+  'cleanliness',
+  3
+);
+
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
+  'ラテ作成/ドージング',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
+  'ラテ作成/タンピング',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
+  'ラテ作成/エスプレッソ抽出',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
+  'ラテ作成/適切なスチーミング',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
+  'ラテ作成/スチームミルクの仕上がり',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
+  'ラテ作成/見た目',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
+  '商品を正しい順番で作成できている',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
+  '全商品を作成できる',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
+  '機械の操作ができる',
+  'skill',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
+  '立ち振舞い',
+  'hospitality',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
+  '感じの良い提供',
+  'hospitality',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
+  'お見送り',
+  'hospitality',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
+  '声掛け',
+  'hospitality',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
+  '強力したオペレーション',
+  'hospitality',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
+  '消費期限の確認',
+  'cleanliness',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
+  '作業台の清潔さ',
+  'cleanliness',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
+  '顔、髪に触れていない',
+  'cleanliness',
+  3
+);
+
+INSERT INTO evaluation_items (
+  id,
+  organization_id,
+  evaluation_section_id,
+  item_name,
+  category,
+  score
+) VALUES (
+  gen_random_uuid(),
+  '11111111-1111-1111-1111-111111111111',
+  'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
+  '異物混入への意識',
+  'cleanliness',
+  3
+);
+

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -284,3 +284,171 @@ INSERT INTO evaluations (
   '勤務スタートから６ヶ月。基本的な作業は出来るようになりました。真面目に仕事を取り組んでいてとても好感が持てます。先輩の後ろ姿を参考にして、マニュアルに無い仕事の動きなど、応用的な力をつけていきましょう。',
   'キャッシャーでは堂々とした対応でお客様へ安心感を届けることができる。バリスタでは商品の作成ミスを無くし、正確に作業ができるようになっている。'
 );
+
+INSERT INTO evaluation_sections (
+  id,
+  organization_id,
+  evaluation_id,
+  section_type,
+  good_points,
+  improvement_points,
+  skill_score,
+  skill_max,
+  hospitality_score,
+  hospitality_max,
+  cleanliness_score,
+  cleanliness_max
+) VALUES (
+  'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
+  '11111111-1111-1111-1111-111111111111',
+  'e1e1e1e1-e1e1-e1e1-e1e1-e1e1e1e1e1e1',
+  'basic',
+  ARRAY['返事が明るくて良い', '遅刻なし', '姿勢が良い', '仲間に対して優しい'],
+  ARRAY[],
+  24,
+  32,
+  15,
+  20,
+  18,
+  24
+);
+
+INSERT INTO evaluation_sections (
+  id,
+  organization_id,
+  evaluation_id,
+  section_type,
+  good_points,
+  improvement_points,
+  skill_score,
+  skill_max,
+  hospitality_score,
+  hospitality_max,
+  cleanliness_score,
+  cleanliness_max
+) VALUES (
+  'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
+  '11111111-1111-1111-1111-111111111111',
+  'e1e1e1e1-e1e1-e1e1-e1e1-e1e1e1e1e1e1',
+  'barista',
+  ARRAY['レジの打ち間違いが無い', '所作がきれい', '笑顔がいい感じ！'],
+  ARRAY['お客さまへの提案が少ない'],
+  27,
+  36,
+  15,
+  20,
+  12,
+  16
+);
+
+INSERT INTO evaluation_sections (
+  id,
+  organization_id,
+  evaluation_id,
+  section_type,
+  good_points,
+  improvement_points,
+  skill_score,
+  skill_max,
+  hospitality_score,
+  hospitality_max,
+  cleanliness_score,
+  cleanliness_max
+) VALUES (
+  'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
+  '11111111-1111-1111-1111-111111111111',
+  'e1e1e1e1-e1e1-e1e1-e1e1-e1e1e1e1e1e1',
+  'cashier',
+  ARRAY['ドリンクの作成が丁寧', '料理の盛り付けが上手'],
+  ARRAY['作業台が少しきたない'],
+  15,
+  20,
+  18,
+  24,
+  21,
+  28
+);
+
+INSERT INTO evaluation_sections (
+  id,
+  organization_id,
+  evaluation_id,
+  section_type,
+  good_points,
+  improvement_points,
+  skill_score,
+  skill_max,
+  hospitality_score,
+  hospitality_max,
+  cleanliness_score,
+  cleanliness_max
+) VALUES (
+  'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
+  '11111111-1111-1111-1111-111111111111',
+  'e2e2e2e2-e2e2-e2e2-e2e2-e2e2e2e2e2e2',
+  'basic',
+  ARRAY['返事が明るくて良い', '元気がある！'],
+  ARRAY['遅刻が多い', 'アレルギー対応に不安がある', '腸内検査提出遅れ'],
+  24,
+  32,
+  15,
+  20,
+  18,
+  24
+);
+
+INSERT INTO evaluation_sections (
+  id,
+  organization_id,
+  evaluation_id,
+  section_type,
+  good_points,
+  improvement_points,
+  skill_score,
+  skill_max,
+  hospitality_score,
+  hospitality_max,
+  cleanliness_score,
+  cleanliness_max
+) VALUES (
+  'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
+  '11111111-1111-1111-1111-111111111111',
+  'e2e2e2e2-e2e2-e2e2-e2e2-e2e2e2e2e2e2',
+  'barista',
+  ARRAY['丁寧な接客', 'レジの打ち間違いが無い'],
+  ARRAY['挨拶の声がちょっと小さい', '目線が低い', '商品券対応に不安がある'],
+  27,
+  36,
+  15,
+  20,
+  12,
+  16
+);
+
+INSERT INTO evaluation_sections (
+  id,
+  organization_id,
+  evaluation_id,
+  section_type,
+  good_points,
+  improvement_points,
+  skill_score,
+  skill_max,
+  hospitality_score,
+  hospitality_max,
+  cleanliness_score,
+  cleanliness_max
+) VALUES (
+  'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
+  '11111111-1111-1111-1111-111111111111',
+  'e2e2e2e2-e2e2-e2e2-e2e2-e2e2e2e2e2e2',
+  'cashier',
+  ARRAY['ひとつひとつの作業が丁寧', 'マニュアルを遵守している'],
+  ARRAY['スチームミルクが荒い', '作業台がきたない', '片付けながら作業ができていない'],
+  15,
+  20,
+  18,
+  24,
+  21,
+  28
+);

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,42 @@
+INSERT INTO auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  confirmation_token,
+  email_change,
+  email_change_token_new,
+  recovery_token
+) VALUES (
+  '00000000-0000-0000-0000-000000000000',
+  'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+  'authenticated',
+  'authenticated',
+  'demo@example.com',
+  crypt('demopage1111', gen_salt('bf')),
+  NOW(),
+  '{"provider":"email","providers":["email"]}'::jsonb,
+  '{}'::jsonb,
+  NOW(),
+  NOW(),
+  '',
+  '',
+  '',
+  ''
+);
+
+UPDATE profiles SET
+  name = 'デモ管理者',
+  role = 'admin',
+  store_name = 'Demo Cafe',
+  organization_id = '11111111-1111-1111-1111-111111111111',
+  is_demo = true,
+  is_setup_complete = true
+WHERE id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -40,3 +40,175 @@ UPDATE profiles SET
   is_demo = true,
   is_setup_complete = true
 WHERE id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+INSERT INTO auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  confirmation_token,
+  email_change,
+  email_change_token_new,
+  recovery_token
+) VALUES (
+  '00000000-0000-0000-0000-000000000000',
+  'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+  'authenticated',
+  'authenticated',
+  'demo1@example.com',
+  crypt('demopage2222', gen_salt('bf')),
+  NOW(),
+  '{"provider":"email","providers":["email"]}'::jsonb,
+  '{}'::jsonb,
+  NOW(),
+  NOW(),
+  '',
+  '',
+  '',
+  ''
+);
+
+UPDATE profiles SET
+  name = 'デモスタッフA',
+  role = 'staff',
+  store_name = 'Demo Cafe',
+  organization_id = '11111111-1111-1111-1111-111111111111',
+  is_demo = true,
+  is_setup_complete = true
+WHERE id = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+
+INSERT INTO auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  confirmation_token,
+  email_change,
+  email_change_token_new,
+  recovery_token
+) VALUES (
+  '00000000-0000-0000-0000-000000000000',
+  'cccccccc-cccc-cccc-cccc-cccccccccccc',
+  'authenticated',
+  'authenticated',
+  'demo2@example.com',
+  crypt('demopage3333', gen_salt('bf')),
+  NOW(),
+  '{"provider":"email","providers":["email"]}'::jsonb,
+  '{}'::jsonb,
+  NOW(),
+  NOW(),
+  '',
+  '',
+  '',
+  ''
+);
+
+UPDATE profiles SET
+  name = 'デモスタッフB',
+  role = 'staff',
+  store_name = 'Demo Cafe',
+  organization_id = '11111111-1111-1111-1111-111111111111',
+  is_demo = true,
+  is_setup_complete = true
+WHERE id = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+
+INSERT INTO auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  confirmation_token,
+  email_change,
+  email_change_token_new,
+  recovery_token
+) VALUES (
+  '00000000-0000-0000-0000-000000000000',
+  'dddddddd-dddd-dddd-dddd-dddddddddddd',
+  'authenticated',
+  'authenticated',
+  'demo3@example.com',
+  crypt('demopage4444', gen_salt('bf')),
+  NOW(),
+  '{"provider":"email","providers":["email"]}'::jsonb,
+  '{}'::jsonb,
+  NOW(),
+  NOW(),
+  '',
+  '',
+  '',
+  ''
+);
+
+UPDATE profiles SET
+  name = 'デモスタッフC',
+  role = 'staff',
+  store_name = 'Demo Cafe',
+  organization_id = '11111111-1111-1111-1111-111111111111',
+  is_demo = true,
+  is_setup_complete = true
+WHERE id = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+
+INSERT INTO auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  confirmation_token,
+  email_change,
+  email_change_token_new,
+  recovery_token
+) VALUES (
+  '00000000-0000-0000-0000-000000000000',
+  'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee',
+  'authenticated',
+  'authenticated',
+  'demo4@example.com',
+  crypt('demopage5555', gen_salt('bf')),
+  NOW(),
+  '{"provider":"email","providers":["email"]}'::jsonb,
+  '{}'::jsonb,
+  NOW(),
+  NOW(),
+  '',
+  '',
+  '',
+  ''
+);
+
+UPDATE profiles SET
+  name = 'デモスタッフD',
+  role = 'staff',
+  store_name = 'Demo Cafe',
+  organization_id = '11111111-1111-1111-1111-111111111111',
+  is_demo = true,
+  is_setup_complete = true
+WHERE id = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee';

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -222,7 +222,7 @@ INSERT INTO evaluation_periods (
   'f1f1f1f1-f1f1-f1f1-f1f1-f1f1f1f1f1f1',
   '11111111-1111-1111-1111-111111111111',
   '2026年4月',
-  false
+  true
 );
 
 INSERT INTO evaluation_periods (
@@ -234,7 +234,7 @@ INSERT INTO evaluation_periods (
   'f2f2f2f2-f2f2-f2f2-f2f2-f2f2f2f2f2f2',
   '11111111-1111-1111-1111-111111111111',
   '2026年7月',
-  true
+  false
 );
 
 INSERT INTO evaluations (
@@ -304,7 +304,7 @@ INSERT INTO evaluation_sections (
   'e1e1e1e1-e1e1-e1e1-e1e1-e1e1e1e1e1e1',
   'basic',
   ARRAY['返事が明るくて良い', '遅刻なし', '姿勢が良い', '仲間に対して優しい'],
-  ARRAY[],
+  ARRAY[]::text[],
   24,
   32,
   15,
@@ -452,24 +452,22 @@ INSERT INTO evaluation_sections (
   21,
   28
 );
-> growth-finder@0.1.0 generate-seed
-> tsx scripts/generate-seed.ts
-
-
 INSERT INTO evaluation_items (
   id,
   organization_id,
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
   '経営理念に沿った行動',
   'skill',
-  3
+  3,
+  ARRAY['内容を理解して自らどう行動するか目標にできている']
 );
 
 INSERT INTO evaluation_items (
@@ -478,14 +476,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
   '出退勤ができる',
   'skill',
-  3
+  3,
+  ARRAY['打刻ルールを理解できている']
 );
 
 INSERT INTO evaluation_items (
@@ -494,14 +494,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
   'シフトを期限内に提出できる',
   'skill',
-  3
+  3,
+  ARRAY['遅れる場合の対応']
 );
 
 INSERT INTO evaluation_items (
@@ -510,14 +512,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
   '早退、欠勤の連絡ができる',
   'skill',
-  3
+  3,
+  ARRAY['当日の場合は電話で連絡', '体調が悪い場合は無理をしない']
 );
 
 INSERT INTO evaluation_items (
@@ -526,14 +530,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
   '自店舗の正しい情報',
   'skill',
-  3
+  3,
+  ARRAY['電話番号', '住所', '営業時間']
 );
 
 INSERT INTO evaluation_items (
@@ -542,14 +548,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
   '守秘義務を理解し守っている',
   'skill',
-  3
+  3,
+  ARRAY['売上', 'マニュアル', 'お客様情報']
 );
 
 INSERT INTO evaluation_items (
@@ -558,14 +566,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
   'シフトインのときのコーヒーテイスティング',
   'skill',
-  3
+  3,
+  ARRAY['銘柄確認', '味わい確認']
 );
 
 INSERT INTO evaluation_items (
@@ -574,14 +584,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
   '電話番号対応ができる',
   'skill',
-  3
+  3,
+  ARRAY['お客様対応', '関係者対応', '保留ボタン']
 );
 
 INSERT INTO evaluation_items (
@@ -590,14 +602,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
   'アレルギー対応',
   'hospitality',
-  3
+  3,
+  ARRAY['アレルギー一覧表の取扱い', 'コンタミネーションの理解']
 );
 
 INSERT INTO evaluation_items (
@@ -606,14 +620,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
   '接客用語に間違いは無いか',
   'hospitality',
-  3
+  3,
+  ARRAY['正しい言葉遣い']
 );
 
 INSERT INTO evaluation_items (
@@ -622,14 +638,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
   'クレーム対応',
   'hospitality',
-  3
+  3,
+  ARRAY['責任者への報連相', '謝罪の言葉がある']
 );
 
 INSERT INTO evaluation_items (
@@ -638,14 +656,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
   '従業員同士の声掛け',
   'hospitality',
-  3
+  3,
+  ARRAY['周りの人へのコミュニケーションがある']
 );
 
 INSERT INTO evaluation_items (
@@ -654,14 +674,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
   '仲間とのやり取り',
   'hospitality',
-  3
+  3,
+  ARRAY['雰囲気作り']
 );
 
 INSERT INTO evaluation_items (
@@ -670,14 +692,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
   'ドレスコードを遵守している',
   'cleanliness',
-  3
+  3,
+  ARRAY['髪が目、頬、肩にかかっていない', '爪']
 );
 
 INSERT INTO evaluation_items (
@@ -686,14 +710,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
   '正しい手洗いができる',
   'cleanliness',
-  3
+  3,
+  ARRAY['手の甲や指と指の間もきれいに洗浄している']
 );
 
 INSERT INTO evaluation_items (
@@ -702,14 +728,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
   '店内環境の整備',
   'cleanliness',
-  3
+  3,
+  ARRAY['客席の整理整頓/清掃', '室温をチェックしている', 'BGMの音量をチェックしている']
 );
 
 INSERT INTO evaluation_items (
@@ -718,14 +746,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
   '腸内検査は毎回提出している',
   'cleanliness',
-  3
+  3,
+  ARRAY['期限内に提出しているか']
 );
 
 INSERT INTO evaluation_items (
@@ -734,14 +764,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
   '厨房内は走らない',
   'cleanliness',
-  3
+  3,
+  ARRAY['早歩きをしている', '急なターンや振り返りが無い']
 );
 
 INSERT INTO evaluation_items (
@@ -750,14 +782,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
   '周囲の安全確認',
   'cleanliness',
-  3
+  3,
+  ARRAY['移動前に周囲を確認する', 'お湯、水など持っていた時は声を掛けている']
 );
 
 
@@ -767,14 +801,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
   'POSレジの基本動作',
   'skill',
-  3
+  3,
+  ARRAY['正確に商品を登録できる']
 );
 
 INSERT INTO evaluation_items (
@@ -783,14 +819,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
   '現金での決済ができる',
   'skill',
-  3
+  3,
+  ARRAY['正確な金銭の授受']
 );
 
 INSERT INTO evaluation_items (
@@ -799,14 +837,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
   'キャッシュレス決済ができる',
   'skill',
-  3
+  3,
+  ARRAY['クレジット', '電子マネー', 'QR']
 );
 
 INSERT INTO evaluation_items (
@@ -815,14 +855,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
   '領収書の発行',
   'skill',
-  3
+  3,
+  ARRAY['手書き発行の際は登録番号を記載']
 );
 
 INSERT INTO evaluation_items (
@@ -831,14 +873,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
   '商品券の取扱い',
   'skill',
-  3
+  3,
+  ARRAY['使用不可の商品券を覚えている']
 );
 
 INSERT INTO evaluation_items (
@@ -847,14 +891,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
   '感じの良いあいさつ',
   'hospitality',
-  3
+  3,
+  ARRAY['笑顔', '声のトーン', '入退店時の挨拶']
 );
 
 INSERT INTO evaluation_items (
@@ -863,14 +909,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
   '感じの良い話し方',
   'hospitality',
-  3
+  3,
+  ARRAY['言葉遣い', 'アイコンタクト', '返事、頷きがある']
 );
 
 INSERT INTO evaluation_items (
@@ -879,14 +927,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
   '立ち振舞い',
   'hospitality',
-  3
+  3,
+  ARRAY['表情', '姿勢', '丁寧な所作']
 );
 
 INSERT INTO evaluation_items (
@@ -895,14 +945,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
   '心のこもった感謝の言葉',
   'hospitality',
-  3
+  3,
+  ARRAY['笑顔', 'アイコンタクト', '声のトーン']
 );
 
 INSERT INTO evaluation_items (
@@ -911,14 +963,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
   'お客様に沿ったおすすめ',
   'hospitality',
-  3
+  3,
+  ARRAY['商品の案内', 'お客様の要望を汲み取れる']
 );
 
 INSERT INTO evaluation_items (
@@ -927,14 +981,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
   'バリスタとの連携',
   'hospitality',
-  3
+  3,
+  ARRAY['アイコンタクトを取りスムーズなオペレーションができる']
 );
 
 INSERT INTO evaluation_items (
@@ -943,14 +999,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
   'ショーケース内の整理整頓',
   'cleanliness',
-  3
+  3,
+  ARRAY['パンくず、ガラス面の指紋の清掃']
 );
 
 INSERT INTO evaluation_items (
@@ -959,14 +1017,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
   'POSレジ周りの整理整頓',
   'cleanliness',
-  3
+  3,
+  ARRAY['ハサミやペンなど散乱していない']
 );
 
 INSERT INTO evaluation_items (
@@ -975,14 +1035,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
   'POSレジ周りの清掃',
   'cleanliness',
-  3
+  3,
+  ARRAY['POSレジのホコリがない', 'ショーケース上部のホコリがない']
 );
 
 INSERT INTO evaluation_items (
@@ -991,14 +1053,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
   '提供時の消費期限の確認',
   'cleanliness',
-  3
+  3,
+  ARRAY['販売前に確認している']
 );
 
 INSERT INTO evaluation_items (
@@ -1007,14 +1071,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
   '異物混入に対しての意識',
   'cleanliness',
-  3
+  3,
+  ARRAY['作業台にゴミがない']
 );
 
 INSERT INTO evaluation_items (
@@ -1023,14 +1089,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
   '動線、転倒防止への配慮',
   'cleanliness',
-  3
+  3,
+  ARRAY['お客様の足元に水滴などがないか', '障害物がないか']
 );
 
 INSERT INTO evaluation_items (
@@ -1039,14 +1107,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3',
   'お客様情報の保護',
   'cleanliness',
-  3
+  3,
+  ARRAY['クレジット情報を盗み見ていない']
 );
 
 
@@ -1056,14 +1126,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
   'ラテ作成/ドージング',
   'skill',
-  3
+  3,
+  ARRAY['ポータフィルターの状態']
 );
 
 INSERT INTO evaluation_items (
@@ -1072,14 +1144,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
   'ラテ作成/タンピング',
   'skill',
-  3
+  3,
+  ARRAY['粉をならし垂直に力をかけている']
 );
 
 INSERT INTO evaluation_items (
@@ -1088,14 +1162,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
   'ラテ作成/エスプレッソ抽出',
   'skill',
-  3
+  3,
+  ARRAY['抽出後のエスプレッソの状態確認']
 );
 
 INSERT INTO evaluation_items (
@@ -1104,14 +1180,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
   'ラテ作成/適切なスチーミング',
   'skill',
-  3
+  3,
+  ARRAY['ワンズの角度', 'ノズルの位置']
 );
 
 INSERT INTO evaluation_items (
@@ -1120,14 +1198,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
   'ラテ作成/スチームミルクの仕上がり',
   'skill',
-  3
+  3,
+  ARRAY['温度', 'キメの細やかさ']
 );
 
 INSERT INTO evaluation_items (
@@ -1136,14 +1216,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
   'ラテ作成/見た目',
   'skill',
-  3
+  3,
+  ARRAY['見た目のきれいさ', 'ツヤがあるか']
 );
 
 INSERT INTO evaluation_items (
@@ -1152,14 +1234,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
   '商品を正しい順番で作成できている',
   'skill',
-  3
+  3,
+  ARRAY['注文を確認して順番に作成できる']
 );
 
 INSERT INTO evaluation_items (
@@ -1168,14 +1252,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
   '全商品を作成できる',
   'skill',
-  3
+  3,
+  ARRAY['ドリンク類', 'フード類']
 );
 
 INSERT INTO evaluation_items (
@@ -1184,14 +1270,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
   '機械の操作ができる',
   'skill',
-  3
+  3,
+  ARRAY['エスプレッソ', 'ドリップ', 'オーブン', '電子レンジ']
 );
 
 INSERT INTO evaluation_items (
@@ -1200,14 +1288,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
   '立ち振舞い',
   'hospitality',
-  3
+  3,
+  ARRAY['表情', '姿勢', '丁寧な所作', '作業音が小さい']
 );
 
 INSERT INTO evaluation_items (
@@ -1216,14 +1306,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
   '感じの良い提供',
   'hospitality',
-  3
+  3,
+  ARRAY['笑顔', 'アイコンタクト', '声のトーン', '挨拶']
 );
 
 INSERT INTO evaluation_items (
@@ -1232,14 +1324,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
   'お見送り',
   'hospitality',
-  3
+  3,
+  ARRAY['お客様が振り返るまで視線を残している']
 );
 
 INSERT INTO evaluation_items (
@@ -1248,14 +1342,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
   '声掛け',
   'hospitality',
-  3
+  3,
+  ARRAY['お客様へ提案できている', '困っているお客様への声掛け']
 );
 
 INSERT INTO evaluation_items (
@@ -1264,14 +1360,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
   '強力したオペレーション',
   'hospitality',
-  3
+  3,
+  ARRAY['報連相ができる']
 );
 
 INSERT INTO evaluation_items (
@@ -1280,14 +1378,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
   '消費期限の確認',
   'cleanliness',
-  3
+  3,
+  ARRAY['常に消費期限をチェックしている', '先入先出を理解している']
 );
 
 INSERT INTO evaluation_items (
@@ -1296,14 +1396,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
   '作業台の清潔さ',
   'cleanliness',
-  3
+  3,
+  ARRAY['汚れはすぐに拭いている', '片付けながら作業できる']
 );
 
 INSERT INTO evaluation_items (
@@ -1312,14 +1414,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
   '顔、髪に触れていない',
   'cleanliness',
-  3
+  3,
+  ARRAY['触れてしまった場合には手洗いをして、清潔な状態を維持している']
 );
 
 INSERT INTO evaluation_items (
@@ -1328,14 +1432,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2',
   '異物混入への意識',
   'cleanliness',
-  3
+  3,
+  ARRAY['ゴミなどが作業台に無い', '調理器具、容器などの破損がない']
 );
 
 
@@ -1345,14 +1451,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
   '経営理念に沿った行動',
   'skill',
-  3
+  3,
+  ARRAY['内容を理解して自らどう行動するか目標にできている']
 );
 
 INSERT INTO evaluation_items (
@@ -1361,14 +1469,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
   '出退勤ができる',
   'skill',
-  3
+  3,
+  ARRAY['打刻ルールを理解できている']
 );
 
 INSERT INTO evaluation_items (
@@ -1377,14 +1487,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
   'シフトを期限内に提出できる',
   'skill',
-  3
+  3,
+  ARRAY['遅れる場合の対応']
 );
 
 INSERT INTO evaluation_items (
@@ -1393,14 +1505,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
   '早退、欠勤の連絡ができる',
   'skill',
-  3
+  3,
+  ARRAY['当日の場合は電話で連絡', '体調が悪い場合は無理をしない']
 );
 
 INSERT INTO evaluation_items (
@@ -1409,14 +1523,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
   '自店舗の正しい情報',
   'skill',
-  3
+  3,
+  ARRAY['電話番号', '住所', '営業時間']
 );
 
 INSERT INTO evaluation_items (
@@ -1425,14 +1541,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
   '守秘義務を理解し守っている',
   'skill',
-  3
+  3,
+  ARRAY['売上', 'マニュアル', 'お客様情報']
 );
 
 INSERT INTO evaluation_items (
@@ -1441,14 +1559,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
   'シフトインのときのコーヒーテイスティング',
   'skill',
-  3
+  3,
+  ARRAY['銘柄確認', '味わい確認']
 );
 
 INSERT INTO evaluation_items (
@@ -1457,14 +1577,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
   '電話番号対応ができる',
   'skill',
-  3
+  3,
+  ARRAY['お客様対応', '関係者対応', '保留ボタン']
 );
 
 INSERT INTO evaluation_items (
@@ -1473,14 +1595,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
   'アレルギー対応',
   'hospitality',
-  3
+  3,
+  ARRAY['アレルギー一覧表の取扱い', 'コンタミネーションの理解']
 );
 
 INSERT INTO evaluation_items (
@@ -1489,14 +1613,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
   '接客用語に間違いは無いか',
   'hospitality',
-  3
+  3,
+  ARRAY['正しい言葉遣い']
 );
 
 INSERT INTO evaluation_items (
@@ -1505,14 +1631,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
   'クレーム対応',
   'hospitality',
-  3
+  3,
+  ARRAY['責任者への報連相', '謝罪の言葉がある']
 );
 
 INSERT INTO evaluation_items (
@@ -1521,14 +1649,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
   '従業員同士の声掛け',
   'hospitality',
-  3
+  3,
+  ARRAY['周りの人へのコミュニケーションがある']
 );
 
 INSERT INTO evaluation_items (
@@ -1537,14 +1667,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
   '仲間とのやり取り',
   'hospitality',
-  3
+  3,
+  ARRAY['雰囲気作り']
 );
 
 INSERT INTO evaluation_items (
@@ -1553,14 +1685,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
   'ドレスコードを遵守している',
   'cleanliness',
-  3
+  3,
+  ARRAY['髪が目、頬、肩にかかっていない', '爪']
 );
 
 INSERT INTO evaluation_items (
@@ -1569,14 +1703,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
   '正しい手洗いができる',
   'cleanliness',
-  3
+  3,
+  ARRAY['手の甲や指と指の間もきれいに洗浄している']
 );
 
 INSERT INTO evaluation_items (
@@ -1585,14 +1721,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
   '店内環境の整備',
   'cleanliness',
-  3
+  3,
+  ARRAY['客席の整理整頓/清掃', '室温をチェックしている', 'BGMの音量をチェックしている']
 );
 
 INSERT INTO evaluation_items (
@@ -1601,14 +1739,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
   '腸内検査は毎回提出している',
   'cleanliness',
-  3
+  3,
+  ARRAY['期限内に提出しているか']
 );
 
 INSERT INTO evaluation_items (
@@ -1617,14 +1757,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
   '厨房内は走らない',
   'cleanliness',
-  3
+  3,
+  ARRAY['早歩きをしている', '急なターンや振り返りが無い']
 );
 
 INSERT INTO evaluation_items (
@@ -1633,14 +1775,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1',
   '周囲の安全確認',
   'cleanliness',
-  3
+  3,
+  ARRAY['移動前に周囲を確認する', 'お湯、水など持っていた時は声を掛けている']
 );
 
 
@@ -1650,14 +1794,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
   'POSレジの基本動作',
   'skill',
-  3
+  3,
+  ARRAY['正確に商品を登録できる']
 );
 
 INSERT INTO evaluation_items (
@@ -1666,14 +1812,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
   '現金での決済ができる',
   'skill',
-  3
+  3,
+  ARRAY['正確な金銭の授受']
 );
 
 INSERT INTO evaluation_items (
@@ -1682,14 +1830,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
   'キャッシュレス決済ができる',
   'skill',
-  3
+  3,
+  ARRAY['クレジット', '電子マネー', 'QR']
 );
 
 INSERT INTO evaluation_items (
@@ -1698,14 +1848,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
   '領収書の発行',
   'skill',
-  3
+  3,
+  ARRAY['手書き発行の際は登録番号を記載']
 );
 
 INSERT INTO evaluation_items (
@@ -1714,14 +1866,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
   '商品券の取扱い',
   'skill',
-  3
+  3,
+  ARRAY['使用不可の商品券を覚えている']
 );
 
 INSERT INTO evaluation_items (
@@ -1730,14 +1884,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
   '感じの良いあいさつ',
   'hospitality',
-  3
+  3,
+  ARRAY['笑顔', '声のトーン', '入退店時の挨拶']
 );
 
 INSERT INTO evaluation_items (
@@ -1746,14 +1902,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
   '感じの良い話し方',
   'hospitality',
-  3
+  3,
+  ARRAY['言葉遣い', 'アイコンタクト', '返事、頷きがある']
 );
 
 INSERT INTO evaluation_items (
@@ -1762,14 +1920,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
   '立ち振舞い',
   'hospitality',
-  3
+  3,
+  ARRAY['表情', '姿勢', '丁寧な所作']
 );
 
 INSERT INTO evaluation_items (
@@ -1778,14 +1938,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
   '心のこもった感謝の言葉',
   'hospitality',
-  3
+  3,
+  ARRAY['笑顔', 'アイコンタクト', '声のトーン']
 );
 
 INSERT INTO evaluation_items (
@@ -1794,14 +1956,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
   'お客様に沿ったおすすめ',
   'hospitality',
-  3
+  3,
+  ARRAY['商品の案内', 'お客様の要望を汲み取れる']
 );
 
 INSERT INTO evaluation_items (
@@ -1810,14 +1974,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
   'バリスタとの連携',
   'hospitality',
-  3
+  3,
+  ARRAY['アイコンタクトを取りスムーズなオペレーションができる']
 );
 
 INSERT INTO evaluation_items (
@@ -1826,14 +1992,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
   'ショーケース内の整理整頓',
   'cleanliness',
-  3
+  3,
+  ARRAY['パンくず、ガラス面の指紋の清掃']
 );
 
 INSERT INTO evaluation_items (
@@ -1842,14 +2010,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
   'POSレジ周りの整理整頓',
   'cleanliness',
-  3
+  3,
+  ARRAY['ハサミやペンなど散乱していない']
 );
 
 INSERT INTO evaluation_items (
@@ -1858,14 +2028,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
   'POSレジ周りの清掃',
   'cleanliness',
-  3
+  3,
+  ARRAY['POSレジのホコリがない', 'ショーケース上部のホコリがない']
 );
 
 INSERT INTO evaluation_items (
@@ -1874,14 +2046,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
   '提供時の消費期限の確認',
   'cleanliness',
-  3
+  3,
+  ARRAY['販売前に確認している']
 );
 
 INSERT INTO evaluation_items (
@@ -1890,14 +2064,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
   '異物混入に対しての意識',
   'cleanliness',
-  3
+  3,
+  ARRAY['作業台にゴミがない']
 );
 
 INSERT INTO evaluation_items (
@@ -1906,14 +2082,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
   '動線、転倒防止への配慮',
   'cleanliness',
-  3
+  3,
+  ARRAY['お客様の足元に水滴などがないか', '障害物がないか']
 );
 
 INSERT INTO evaluation_items (
@@ -1922,14 +2100,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3',
   'お客様情報の保護',
   'cleanliness',
-  3
+  3,
+  ARRAY['クレジット情報を盗み見ていない']
 );
 
 
@@ -1939,14 +2119,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
   'ラテ作成/ドージング',
   'skill',
-  3
+  3,
+  ARRAY['ポータフィルターの状態']
 );
 
 INSERT INTO evaluation_items (
@@ -1955,14 +2137,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
   'ラテ作成/タンピング',
   'skill',
-  3
+  3,
+  ARRAY['粉をならし垂直に力をかけている']
 );
 
 INSERT INTO evaluation_items (
@@ -1971,14 +2155,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
   'ラテ作成/エスプレッソ抽出',
   'skill',
-  3
+  3,
+  ARRAY['抽出後のエスプレッソの状態確認']
 );
 
 INSERT INTO evaluation_items (
@@ -1987,14 +2173,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
   'ラテ作成/適切なスチーミング',
   'skill',
-  3
+  3,
+  ARRAY['ワンズの角度', 'ノズルの位置']
 );
 
 INSERT INTO evaluation_items (
@@ -2003,14 +2191,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
   'ラテ作成/スチームミルクの仕上がり',
   'skill',
-  3
+  3,
+  ARRAY['温度', 'キメの細やかさ']
 );
 
 INSERT INTO evaluation_items (
@@ -2019,14 +2209,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
   'ラテ作成/見た目',
   'skill',
-  3
+  3,
+  ARRAY['見た目のきれいさ', 'ツヤがあるか']
 );
 
 INSERT INTO evaluation_items (
@@ -2035,14 +2227,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
   '商品を正しい順番で作成できている',
   'skill',
-  3
+  3,
+  ARRAY['注文を確認して順番に作成できる']
 );
 
 INSERT INTO evaluation_items (
@@ -2051,14 +2245,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
   '全商品を作成できる',
   'skill',
-  3
+  3,
+  ARRAY['ドリンク類', 'フード類']
 );
 
 INSERT INTO evaluation_items (
@@ -2067,14 +2263,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
   '機械の操作ができる',
   'skill',
-  3
+  3,
+  ARRAY['エスプレッソ', 'ドリップ', 'オーブン', '電子レンジ']
 );
 
 INSERT INTO evaluation_items (
@@ -2083,14 +2281,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
   '立ち振舞い',
   'hospitality',
-  3
+  3,
+  ARRAY['表情', '姿勢', '丁寧な所作', '作業音が小さい']
 );
 
 INSERT INTO evaluation_items (
@@ -2099,14 +2299,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
   '感じの良い提供',
   'hospitality',
-  3
+  3,
+  ARRAY['笑顔', 'アイコンタクト', '声のトーン', '挨拶']
 );
 
 INSERT INTO evaluation_items (
@@ -2115,14 +2317,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
   'お見送り',
   'hospitality',
-  3
+  3,
+  ARRAY['お客様が振り返るまで視線を残している']
 );
 
 INSERT INTO evaluation_items (
@@ -2131,14 +2335,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
   '声掛け',
   'hospitality',
-  3
+  3,
+  ARRAY['お客様へ提案できている', '困っているお客様への声掛け']
 );
 
 INSERT INTO evaluation_items (
@@ -2147,14 +2353,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
   '強力したオペレーション',
   'hospitality',
-  3
+  3,
+  ARRAY['報連相ができる']
 );
 
 INSERT INTO evaluation_items (
@@ -2163,14 +2371,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
   '消費期限の確認',
   'cleanliness',
-  3
+  3,
+  ARRAY['常に消費期限をチェックしている', '先入先出を理解している']
 );
 
 INSERT INTO evaluation_items (
@@ -2179,14 +2389,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
   '作業台の清潔さ',
   'cleanliness',
-  3
+  3,
+  ARRAY['汚れはすぐに拭いている', '片付けながら作業できる']
 );
 
 INSERT INTO evaluation_items (
@@ -2195,14 +2407,16 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
   '顔、髪に触れていない',
   'cleanliness',
-  3
+  3,
+  ARRAY['触れてしまった場合には手洗いをして、清潔な状態を維持している']
 );
 
 INSERT INTO evaluation_items (
@@ -2211,13 +2425,15 @@ INSERT INTO evaluation_items (
   evaluation_section_id,
   item_name,
   category,
-  score
+  score,
+  check_points
 ) VALUES (
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
   '異物混入への意識',
   'cleanliness',
-  3
+  3,
+  ARRAY['ゴミなどが作業台に無い', '調理器具、容器などの破損がない']
 );
 

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -212,3 +212,27 @@ UPDATE profiles SET
   is_demo = true,
   is_setup_complete = true
 WHERE id = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee';
+
+INSERT INTO evaluation_periods (
+  id,
+  organization_id,
+  name,
+  is_current
+) VALUES (
+  'f1f1f1f1-f1f1-f1f1-f1f1-f1f1f1f1f1f1',
+  '11111111-1111-1111-1111-111111111111',
+  '2026年4月',
+  false
+);
+
+INSERT INTO evaluation_periods (
+  id,
+  organization_id,
+  name,
+  is_current
+) VALUES (
+  'f2f2f2f2-f2f2-f2f2-f2f2-f2f2f2f2f2f2',
+  '11111111-1111-1111-1111-111111111111',
+  '2026年7月',
+  true
+);

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -236,3 +236,51 @@ INSERT INTO evaluation_periods (
   '2026年7月',
   true
 );
+
+INSERT INTO evaluations (
+  id,
+  organization_id,
+  evaluation_period_id,
+  staff_id,
+  evaluator_id,
+  evaluation_date,
+  status,
+  action_plan,
+  total_comment,
+  future_vision
+) VALUES (
+  'e1e1e1e1-e1e1-e1e1-e1e1-e1e1e1e1e1e1',
+  '11111111-1111-1111-1111-111111111111',
+  'f1f1f1f1-f1f1-f1f1-f1f1-f1f1f1f1f1f1',
+  'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+  'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+  NOW(),
+  'completed',
+  '基本動作：自分から後輩へ声をかけて良い関係を築く。バリスタ：毎日カフェラテの練習をする。 キャッシャー：お客さまへ、天気や注文されたものなど些細なことでもいいので声をかける。',
+  '総合的にみて仕事はある程度できます。仕事がとても丁寧で好感がもてます。次のステップとして後輩を指導してお店の中心になっていきましょう。',
+  'キャッシャーでは自らお客様へ商品を進めることができる。バリスタでは忙しい時間帯でもカフェラテをきれいに作成できるようになっている。後輩を指導できている。'
+);
+
+INSERT INTO evaluations (
+  id,
+  organization_id,
+  evaluation_period_id,
+  staff_id,
+  evaluator_id,
+  evaluation_date,
+  status,
+  action_plan,
+  total_comment,
+  future_vision
+) VALUES (
+  'e2e2e2e2-e2e2-e2e2-e2e2-e2e2e2e2e2e2',
+  '11111111-1111-1111-1111-111111111111',
+  'f1f1f1f1-f1f1-f1f1-f1f1-f1f1f1f1f1f1',
+  'cccccccc-cccc-cccc-cccc-cccccccccccc',
+  'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+  NOW(),
+  'completed',
+  '基本動作：腸内検査、シフト提出期限を守りましょう。信頼につながります。バリスタ：マニュアルを暗記できていないところがあるので、勤務前にしっかりと確認しましょう。キャッシャー：緊張で声が小さくなる場面があるので、徐々に声のボリュームを上げましょう。',
+  '勤務スタートから６ヶ月。基本的な作業は出来るようになりました。真面目に仕事を取り組んでいてとても好感が持てます。先輩の後ろ姿を参考にして、マニュアルに無い仕事の動きなど、応用的な力をつけていきましょう。',
+  'キャッシャーでは堂々とした対応でお客様へ安心感を届けることができる。バリスタでは商品の作成ミスを無くし、正確に作業ができるようになっている。'
+);


### PR DESCRIPTION
## 概要
ユーザーがお試しでアプリを体験できるデモルートの実装

## 対応

### 4月26日
- app/demo/route.tsにルートハンドラーを設置

### 4月27日
- デモモードを知らせるバナーを実装
- 設定ページでプロフィール、パスワードのフォームを非表示に修正

### 4月28日
- seed.sqlにデモ管理者を登録するsql追加
- seed.sqlにデモスタッフ４名分を登録するsql追加
- seed.sqlに評価期間を登録するsql追加
- seed.sqlにevaluationsを登録するsql追加
- evaluation_itemsを登録するsqlを出力するヘルパー関数を作成
- seed.sqlにevaluation_sectionsを登録するsqlを追加
- generateSeed関数を実行してseed.sqlにevaluation_itemsを登録するsqlを追加

### 4月29日
- スタッフカードメニューのプロフィール、パスワード、削除を制限
- プロフィール詳細ページのアバター、プロフィール編集を制限

## 設計理由
**app/demo/route.tsにルートハンドラーを設置した理由**
始めにserver componentsで実装するため、app/demo/page.tsxを設置し、supabase.auth.signInWithPassword()のあとにredirect('/admin')で遷移させようとしていた。
しかしこの方法ではセッションがCookieに保存される前にリダイレクトが走るのでmiddlewareでuserがnullになり/loginへリダイレクトされる。
解決方法としてRoute Handlerを使うと、レスポンスにCookieを設定後にリダイレクトされるのでmiddlewareでuserの値が取得できるのでログインでき、/adminへ遷移することができた。

**Demo関連のコンポーネントでis_demoを受け取り表示するかどうかの判断をコンポーネント自身に持たせた理由**
is_demoをフラグに三項演算子でコンポーネントを出し分ける方法も検討した。
しかしそうなるとコンポーネントを出し分ける責務はlayout.tsxが担うようになり、今後デモかつ特定のページだけ表示するパターンなどの実装が増えた際に保守性が下がる。
そこでコンポーネント自身に表示するかしないかの責務を持たせることで呼び出し側をシンプルに保ち、拡張しやすいと思ったので採用した。

**seedデータのusers, profiles, organization_id, evaluations, evaluation_sectionsのidを固定値にした理由**
seedデータは何度実行しても同じ結果にする必要がある。
gen_random_uuid()などを使ってidを生成してしまうと実行するたびに異なるUUIDが生成される。
１回目と２回目のidが異なる場合、evaluation_sectionsのidをevaluation_itemsが参照できなくなるため固定値にした。
また、organization_idも固定値にすることで管理者・スタッフ・評価データが同じ組織に属することを保証している。

**generateSeed関数を作成した理由**
evaluation_itemsは全55項目×スタッフ２名分=110件のINSERTが必要だった。
手書きでは量が多く、items_nameのタイポやsection_idの間違いなどのミスが発生しやすい。
アプリ側にSECTION_ITEMSの定数ファイルがすでに存在していたため、
それをimportしてSQL文字列を自動生成するスクリプトを作成した。
定数ファイルからの自動生成なのでitem_nameの一致も保証される。

