### PR TITLE
fix: ルートハンドラーのintentが無い場合に/loginへ遷移させるように変更

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -78,5 +78,5 @@ export async function GET(request: Request) {
   }
 
   //intentがない場合
-  return NextResponse.redirect(new URL('/admin', origin));
+  return NextResponse.redirect(new URL('/login', origin));
 }


### PR DESCRIPTION
## 概要
app/auth/callback/route.tsにてintentが無い場合に/adminへ遷移するコードの修正

## 対応
intentが無い場合
return NextResponse.redirect(new URL('/login', origin))へ変更

## 原因
intentを削ったURLでcallbackを叩くと、無条件で/adminへ行く。
実際にはmiddlewareが阻止するがcallback単体で見ると安全ではない。