### PR TITLE
fix: 空のSectionData型をもつオブジェクトを生成するファクトリー関数を作成し適用

### DIFF
--- a/src/app/(protected)/admin/staff/[staffId]/evaluation/utils.ts
+++ b/src/app/(protected)/admin/staff/[staffId]/evaluation/utils.ts
@@ -5,26 +5,21 @@ import {
   FormattedEvaluation,
 } from '../../../../../../../types/evaluations';
 
-const EMPTY_SECTION_DATA: SectionData = {
+const createEmptySectionData = (): SectionData => ({
   skill: {},
   hospitality: {},
   cleanliness: {},
   good_points: [],
   improvement_points: [],
-};
+});
 
 //evaluation_itemsをcategoryごとに{item_name: score}の形に整形する
 export const formatCategoryScores = (items: EvaluationItem[]) =>
-  items.reduce<SectionData>(
-    (acc, cur) => {
-      if (!acc[cur.category]) acc[cur.category] = {};
-      acc[cur.category][cur.item_name] = cur.score ?? 0;
-      return acc;
-    },
-    {
-      ...EMPTY_SECTION_DATA,
-    }
-  );
+  items.reduce<SectionData>((acc, cur) => {
+    if (!acc[cur.category]) acc[cur.category] = {};
+    acc[cur.category][cur.item_name] = cur.score ?? 0;
+    return acc;
+  }, createEmptySectionData());
 
 //既存評価データをEvaluationFormのdefaultValues形式に整形する
 export const formatEvaluationData = (
@@ -41,15 +36,9 @@ export const formatEvaluationData = (
         return acc;
       },
       {
-        basic: {
-          ...EMPTY_SECTION_DATA,
-        },
-        barista: {
-          ...EMPTY_SECTION_DATA,
-        },
-        cashier: {
-          ...EMPTY_SECTION_DATA,
-        },
+        basic: createEmptySectionData(),
+        barista: createEmptySectionData(),
+        cashier: createEmptySectionData(),
       }
     );
 


### PR DESCRIPTION
## 概要
シャローコピーによるセクション間のデータ混入

## 対応
空のSectionData型をもつオブジェクトを生成するファクトリー関数を作成し適用

## 原因
EMPTY_SECTION_DATA をスプレッド演算子で初期化していたため、内側のオブジェクト(skill/hospitality/cleanliness)の参照が
3セクションで共有されていた。
その結果、reduce で各セクションの項目を書き込むたびに、
すべてのセクションの内側オブジェクトに項目が積み上がっていた。

## 解決策
EMPTY_SECTION_DATA を定数から createEmptySectionData 関数に変更し、
呼び出すたびに新しいオブジェクトを生成する形に修正。