### PR TITLE
fix: useEffect内のsetStateにeslint-disableコメントを追加

### DIFF
--- a/src/app/(auth)/login/login-form.tsx
+++ b/src/app/(auth)/login/login-form.tsx
@@ -35,10 +35,13 @@ export default function LoginForm() {
     const method = localStorage.getItem('lastLoginMethod');
     const tab = localStorage.getItem('lastLoginTab');
 
+    // マウント時にlocalStorageから初期値を読み込むための意図的なsetState
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setLastLoginMethod(method);
 
     if (tab !== 'admin' && tab !== 'staff') return;
 
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setActiveTab(tab);
   }, []);
 


### PR DESCRIPTION
## 概要
login-form.tsxのuseEffect内でuseStateを呼んでいる箇所にeslint-disableコメントを追加してESLintエラーを解消した。

## 原因
Next.js App RouterではSSRのためuseStateの初期値でlocalStorageにアクセスできない。
そのためuseEffect内でlocalStorageを読み込み、setStateで初期値を設定する実装になっている。
依存配列が[]のためカスケードレンダリングは発生しない。
ESLintのreact-hooks/set-state-in-effectルールは
パターンとして機械的に警告するため、意図を明示した上で抑制した。

## 今後の対応
localStorageからCookieへの移行をissue #145で管理する。
Cookieに移行することでSSRで初期値を取得できるようになり、
useEffectとeslint-disableが不要になる予定。