### PR TITLE
テスト追加とCIにESLint追加

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,5 +20,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Run check
+        run: npm run check
+
       - name: Run tests
         run: npm run test

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -24,7 +24,13 @@ const eslintConfig = defineConfig([
       'no-var': 'error',
     },
   },
-  globalIgnores(['.next/**', 'out/**', 'build/**', 'next-env.d.ts']),
+  globalIgnores([
+    '.next/**',
+    'out/**',
+    'build/**',
+    'next-env.d.ts',
+    'scripts/**',
+  ]),
 ]);
 
 export default eslintConfig;

--- a/src/app/(auth)/login/login-form.tsx
+++ b/src/app/(auth)/login/login-form.tsx
@@ -35,10 +35,13 @@ export default function LoginForm() {
     const method = localStorage.getItem('lastLoginMethod');
     const tab = localStorage.getItem('lastLoginTab');
 
+    // マウント時にlocalStorageから初期値を読み込むための意図的なsetState
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setLastLoginMethod(method);
 
     if (tab !== 'admin' && tab !== 'staff') return;
 
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setActiveTab(tab);
   }, []);
 

--- a/src/app/(auth)/login/login-form.tsx
+++ b/src/app/(auth)/login/login-form.tsx
@@ -41,7 +41,6 @@ export default function LoginForm() {
 
     if (tab !== 'admin' && tab !== 'staff') return;
 
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     setActiveTab(tab);
   }, []);
 

--- a/src/app/(protected)/admin/staff/[staffId]/evaluation/utils.test.ts
+++ b/src/app/(protected)/admin/staff/[staffId]/evaluation/utils.test.ts
@@ -1,5 +1,6 @@
-import { formatEvaluationData } from './utils';
+import { formatCategoryScores, formatEvaluationData } from './utils';
 import {
+  EvaluationItem,
   ExistingEvaluation,
   FormattedEvaluation,
 } from '../../../../../../../types/evaluations';
@@ -90,6 +91,22 @@ describe('formatEvaluationData', () => {
 
     expect(result).toEqual(expected);
   });
+});
 
-  it('scoreがnullのとき0のフォールバックが機能している', () => {});
+describe('formatCategoryScores', () => {
+  it('scoreがnullまたはundefinedのとき、0にフォールバックされること', () => {
+    const input: EvaluationItem[] = [
+      { item_name: 'item-1', category: 'skill', score: null as any },
+      { item_name: 'item-2', category: 'hospitality', score: undefined as any },
+      { item_name: 'item-3', category: 'cleanliness', score: null as any },
+    ];
+
+    const result = formatCategoryScores(input);
+
+    expect(result.skill['item-1']).toBe(0);
+    expect(result.hospitality['item-2']).toBe(0);
+    expect(result.cleanliness['item-3']).toBe(0);
+  });
+
+  it('')
 });

--- a/src/app/(protected)/admin/staff/[staffId]/evaluation/utils.test.ts
+++ b/src/app/(protected)/admin/staff/[staffId]/evaluation/utils.test.ts
@@ -96,8 +96,12 @@ describe('formatEvaluationData', () => {
 describe('formatCategoryScores', () => {
   it('scoreがnullまたはundefinedのとき、0にフォールバックされること', () => {
     const input: EvaluationItem[] = [
+      // 実行時に型外の値が渡された場合のフォールバックを検証するため意図的にas anyを使用
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       { item_name: 'item-1', category: 'skill', score: null as any },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       { item_name: 'item-2', category: 'hospitality', score: undefined as any },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       { item_name: 'item-3', category: 'cleanliness', score: null as any },
     ];
 

--- a/src/app/(protected)/admin/staff/[staffId]/evaluation/utils.test.ts
+++ b/src/app/(protected)/admin/staff/[staffId]/evaluation/utils.test.ts
@@ -108,5 +108,15 @@ describe('formatCategoryScores', () => {
     expect(result.cleanliness['item-3']).toBe(0);
   });
 
-  it('')
+  it('空の配列が渡された場合、初期化されたSectionDataを返す', () => {
+    const result = formatCategoryScores([]);
+
+    expect(result).toEqual({
+      skill: {},
+      hospitality: {},
+      cleanliness: {},
+      good_points: [],
+      improvement_points: [],
+    });
+  });
 });

--- a/src/app/(protected)/admin/staff/[staffId]/evaluation/utils.test.ts
+++ b/src/app/(protected)/admin/staff/[staffId]/evaluation/utils.test.ts
@@ -90,4 +90,6 @@ describe('formatEvaluationData', () => {
 
     expect(result).toEqual(expected);
   });
+
+  it('', () => {});
 });

--- a/src/app/(protected)/admin/staff/[staffId]/evaluation/utils.test.ts
+++ b/src/app/(protected)/admin/staff/[staffId]/evaluation/utils.test.ts
@@ -91,5 +91,5 @@ describe('formatEvaluationData', () => {
     expect(result).toEqual(expected);
   });
 
-  it('', () => {});
+  it('scoreがnullのとき0のフォールバックが機能している', () => {});
 });


### PR DESCRIPTION
## 概要
formatCategoryScoresのテストを追加し、CIにESLintと型チェックを追加

## 変更内容
### テスト
- formatCategoryScoresのscoreがnullまたはundefinedのとき、0にフォールバックされるかのテスト追加
- formatCategoryScoresに空の配列を渡した場合、初期化されたSectionDataを返すかのテスト追加

### バグ修正
- login-form.tsxのuseEffect内setStateにeslint-disableコメントを追加
- SSRのためlocalStorageはuseEffect内でのみアクセス可能
- Cookieへの移行はissueで管理

### CI
- test.ymlにnpm run check(ESLint + TypeScript型チェック)を追加
- scripts/**をESLintの対象から除外