### PR TITLE
Fix/#149

### DIFF
--- a/src/app/(protected)/admin/staff/components/staff-card-menu.tsx
+++ b/src/app/(protected)/admin/staff/components/staff-card-menu.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Dispatch, SetStateAction, useRef, useState } from 'react';
+import { Dispatch, SetStateAction, useMemo, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import {
   AlertDialog,
@@ -49,6 +49,7 @@ import {
 import { uploadStaffAvatar } from '@/lib/utils/upload';
 import Link from 'next/link';
 import { Tables } from '../../../../../../types/supabase';
+import { cn } from '@/lib/utils';
 
 type EvaluationPeriod = Pick<Tables<'evaluation_periods'>, 'id'> | null;
 
@@ -80,6 +81,12 @@ type EditPasswordDialogProps = {
   setIsEditPasswordOpen: Dispatch<SetStateAction<boolean>>;
 };
 
+const DemoBadge = (
+  <span className="ml-1 text-[9px] font-nomal leading-none text-muted-foreground opacity-70">
+    デモモードのため不可
+  </span>
+);
+
 export default function StaffCardMenu({
   isDemo,
   staff,
@@ -89,10 +96,28 @@ export default function StaffCardMenu({
   const [isEditOpen, setIsEditOpen] = useState(false);
   const [isEditPasswordOpen, setIsEditPasswordOpen] = useState(false);
 
-  const DemoBadge = (
-    <span className="ml-1 text-[9px] font-nomal leading-none opacity-70">
-      デモモードのため不可
-    </span>
+  const menuItems = useMemo(
+    () => [
+      {
+        icon: Icons.Pencil,
+        label: '編集',
+        className: '',
+        onSelect: () => setIsEditOpen(true),
+      },
+      {
+        icon: Icons.KeyRound,
+        label: 'パスワード変更',
+        className: '',
+        onSelect: () => setIsEditPasswordOpen(true),
+      },
+      {
+        icon: Icons.Trash2,
+        label: '削除',
+        className: 'cursor-pointer text-destructive',
+        onSelect: () => setIsDeleteOpen(true),
+      },
+    ],
+    [isDemo]
   );
 
   return (
@@ -126,61 +151,26 @@ export default function StaffCardMenu({
             </DropdownMenuItem>
           )}
 
-          {isDemo ? (
-            <DropdownMenuItem
-              disabled
-              className="cursor-not-allowed text-muted-foreground"
-            >
-              <Icons.Pencil className="mr-2 size-4" />
-              編集
-              {DemoBadge}
-            </DropdownMenuItem>
-          ) : (
-            <DropdownMenuItem
-              className="cursor-pointer"
-              onSelect={() => setIsEditOpen(true)}
-            >
-              <Icons.Pencil className="mr-2 size-4" />
-              編集
-            </DropdownMenuItem>
-          )}
-
-          {isDemo ? (
-            <DropdownMenuItem
-              disabled
-              className="cursor-not-allowed text-muted-foreground"
-            >
-              <Icons.KeyRound className="mr-2 size-4" />
-              パスワード変更
-              {DemoBadge}
-            </DropdownMenuItem>
-          ) : (
-            <DropdownMenuItem
-              className="cursor-pointer"
-              onSelect={() => setIsEditPasswordOpen(true)}
-            >
-              <Icons.KeyRound className="mr-2 size-4" />
-              パスワード変更
-            </DropdownMenuItem>
-          )}
-          {isDemo ? (
-            <DropdownMenuItem
-              disabled
-              className="cursor-not-allowed text-muted-foreground"
-            >
-              <Icons.Trash2 className="mr-2 size-4" />
-              削除
-              {DemoBadge}
-            </DropdownMenuItem>
-          ) : (
-            <DropdownMenuItem
-              onSelect={() => setIsDeleteOpen(true)}
-              className="cursor-pointer text-destructive"
-            >
-              <Icons.Trash2 className="mr-2 size-4" />
-              削除
-            </DropdownMenuItem>
-          )}
+          {menuItems.map((item) => {
+            const Icon = item.icon;
+            return (
+              <DropdownMenuItem
+                key={item.label}
+                disabled={isDemo}
+                className={cn(
+                  isDemo
+                    ? 'cursor-not-allowed text-muted-foreground'
+                    : 'cursor-pointer',
+                  item.className
+                )}
+                onSelect={isDemo ? undefined : item.onSelect}
+              >
+                <Icon className="mr-2 size-4" />
+                {item.label}
+                {isDemo && DemoBadge}
+              </DropdownMenuItem>
+            );
+          })}
         </DropdownMenuContent>
       </DropdownMenu>
 

--- a/src/app/(protected)/admin/staff/components/staff-card-menu.tsx
+++ b/src/app/(protected)/admin/staff/components/staff-card-menu.tsx
@@ -80,6 +80,126 @@ type EditPasswordDialogProps = {
   setIsEditPasswordOpen: Dispatch<SetStateAction<boolean>>;
 };
 
+export default function StaffCardMenu({
+  isDemo,
+  staff,
+  selectedPeriod,
+}: StaffCardMenuProps) {
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+  const [isEditOpen, setIsEditOpen] = useState(false);
+  const [isEditPasswordOpen, setIsEditPasswordOpen] = useState(false);
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" size="icon" className="size-8">
+            <Icons.EllipsisVerticalIcon className="size-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem asChild className="cursor-pointer">
+            <Link href={`/admin/staff/${staff.id}`}>
+              <Icons.FileText className="mr-2 size-4" />
+              詳細
+            </Link>
+          </DropdownMenuItem>
+          {selectedPeriod ? (
+            <DropdownMenuItem asChild className="cursor-pointer">
+              <Link
+                href={`/admin/staff/${staff.id}/evaluation?periodId=${selectedPeriod.id}`}
+              >
+                <Icons.ClipboardList className="mr-2 size-4" />
+                評価
+              </Link>
+            </DropdownMenuItem>
+          ) : (
+            <DropdownMenuItem disabled>
+              <Icons.ClipboardList className="mr-2 size-4" />
+              評価(期間未選択)
+            </DropdownMenuItem>
+          )}
+
+          {isDemo ? (
+            <DropdownMenuItem
+              disabled
+              className="cursor-not-allowed text-muted-foreground"
+            >
+              <Icons.Pencil className="mr-2 size-4" />
+              編集（デモモードのため不可）
+            </DropdownMenuItem>
+          ) : (
+            <DropdownMenuItem
+              className="cursor-pointer"
+              onSelect={() => setIsEditOpen(true)}
+            >
+              <Icons.Pencil className="mr-2 size-4" />
+              編集
+            </DropdownMenuItem>
+          )}
+
+          {isDemo ? (
+            <DropdownMenuItem
+              disabled
+              className="cursor-not-allowed text-muted-foreground"
+            >
+              <Icons.KeyRound className="mr-2 size-4" />
+              パスワード変更(デモモードのため不可)
+            </DropdownMenuItem>
+          ) : (
+            <DropdownMenuItem
+              className="cursor-pointer"
+              onSelect={() => setIsEditPasswordOpen(true)}
+            >
+              <Icons.KeyRound className="mr-2 size-4" />
+              パスワード変更
+            </DropdownMenuItem>
+          )}
+          {isDemo ? (
+            <DropdownMenuItem
+              disabled
+              className="cursor-not-allowed text-muted-foreground"
+            >
+              <Icons.Trash2 className="mr-2 size-4" />
+              削除（デモモードのため不可）
+            </DropdownMenuItem>
+          ) : (
+            <DropdownMenuItem
+              onSelect={() => setIsDeleteOpen(true)}
+              className="cursor-pointer text-destructive"
+            >
+              <Icons.Trash2 className="mr-2 size-4" />
+              削除
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <DeleteDialog
+        staffName={staff.name}
+        staffId={staff.id}
+        isDeleteOpen={isDeleteOpen}
+        setIsDeleteOpen={setIsDeleteOpen}
+      />
+
+      <EditDialog
+        staffId={staff.id}
+        staffName={staff.name}
+        staffEmail={staff.email}
+        staffAvatarUrl={staff.avatar_url}
+        isEditOpen={isEditOpen}
+        setIsEditOpen={setIsEditOpen}
+      />
+
+      <EditPasswordDialog
+        staffId={staff.id}
+        isEditPasswordOpen={isEditPasswordOpen}
+        setIsEditPasswordOpen={setIsEditPasswordOpen}
+      />
+    </>
+  );
+}
+
 function DeleteDialog({
   staffName,
   staffId,
@@ -339,125 +459,5 @@ function EditPasswordDialog({
         </form>
       </DialogContent>
     </Dialog>
-  );
-}
-
-export default function StaffCardMenu({
-  isDemo,
-  staff,
-  selectedPeriod,
-}: StaffCardMenuProps) {
-  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
-  const [isEditOpen, setIsEditOpen] = useState(false);
-  const [isEditPasswordOpen, setIsEditPasswordOpen] = useState(false);
-
-  return (
-    <>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button variant="ghost" size="icon" className="size-8">
-            <Icons.EllipsisVerticalIcon className="size-4" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          <DropdownMenuItem asChild className="cursor-pointer">
-            <Link href={`/admin/staff/${staff.id}`}>
-              <Icons.FileText className="mr-2 size-4" />
-              詳細
-            </Link>
-          </DropdownMenuItem>
-          {selectedPeriod ? (
-            <DropdownMenuItem asChild className="cursor-pointer">
-              <Link
-                href={`/admin/staff/${staff.id}/evaluation?periodId=${selectedPeriod.id}`}
-              >
-                <Icons.ClipboardList className="mr-2 size-4" />
-                評価
-              </Link>
-            </DropdownMenuItem>
-          ) : (
-            <DropdownMenuItem disabled>
-              <Icons.ClipboardList className="mr-2 size-4" />
-              評価(期間未選択)
-            </DropdownMenuItem>
-          )}
-
-          {isDemo ? (
-            <DropdownMenuItem
-              disabled
-              className="cursor-not-allowed text-muted-foreground"
-            >
-              <Icons.Pencil className="mr-2 size-4" />
-              編集（デモモードのため不可）
-            </DropdownMenuItem>
-          ) : (
-            <DropdownMenuItem
-              className="cursor-pointer"
-              onSelect={() => setIsEditOpen(true)}
-            >
-              <Icons.Pencil className="mr-2 size-4" />
-              編集
-            </DropdownMenuItem>
-          )}
-
-          {isDemo ? (
-            <DropdownMenuItem
-              disabled
-              className="cursor-not-allowed text-muted-foreground"
-            >
-              <Icons.KeyRound className="mr-2 size-4" />
-              パスワード変更(デモモードのため不可)
-            </DropdownMenuItem>
-          ) : (
-            <DropdownMenuItem
-              className="cursor-pointer"
-              onSelect={() => setIsEditPasswordOpen(true)}
-            >
-              <Icons.KeyRound className="mr-2 size-4" />
-              パスワード変更
-            </DropdownMenuItem>
-          )}
-          {isDemo ? (
-            <DropdownMenuItem
-              disabled
-              className="cursor-not-allowed text-muted-foreground"
-            >
-              <Icons.Trash2 className="mr-2 size-4" />
-              削除（デモモードのため不可）
-            </DropdownMenuItem>
-          ) : (
-            <DropdownMenuItem
-              onSelect={() => setIsDeleteOpen(true)}
-              className="cursor-pointer text-destructive"
-            >
-              <Icons.Trash2 className="mr-2 size-4" />
-              削除
-            </DropdownMenuItem>
-          )}
-        </DropdownMenuContent>
-      </DropdownMenu>
-
-      <DeleteDialog
-        staffName={staff.name}
-        staffId={staff.id}
-        isDeleteOpen={isDeleteOpen}
-        setIsDeleteOpen={setIsDeleteOpen}
-      />
-
-      <EditDialog
-        staffId={staff.id}
-        staffName={staff.name}
-        staffEmail={staff.email}
-        staffAvatarUrl={staff.avatar_url}
-        isEditOpen={isEditOpen}
-        setIsEditOpen={setIsEditOpen}
-      />
-
-      <EditPasswordDialog
-        staffId={staff.id}
-        isEditPasswordOpen={isEditPasswordOpen}
-        setIsEditPasswordOpen={setIsEditPasswordOpen}
-      />
-    </>
   );
 }

--- a/src/app/(protected)/admin/staff/components/staff-card-menu.tsx
+++ b/src/app/(protected)/admin/staff/components/staff-card-menu.tsx
@@ -89,6 +89,12 @@ export default function StaffCardMenu({
   const [isEditOpen, setIsEditOpen] = useState(false);
   const [isEditPasswordOpen, setIsEditPasswordOpen] = useState(false);
 
+  const DemoBadge = (
+    <span className="ml-1 text-[9px] font-nomal leading-none opacity-70">
+      デモモードのため不可
+    </span>
+  );
+
   return (
     <>
       <DropdownMenu>
@@ -126,7 +132,8 @@ export default function StaffCardMenu({
               className="cursor-not-allowed text-muted-foreground"
             >
               <Icons.Pencil className="mr-2 size-4" />
-              編集（デモモードのため不可）
+              編集
+              {DemoBadge}
             </DropdownMenuItem>
           ) : (
             <DropdownMenuItem
@@ -144,7 +151,8 @@ export default function StaffCardMenu({
               className="cursor-not-allowed text-muted-foreground"
             >
               <Icons.KeyRound className="mr-2 size-4" />
-              パスワード変更(デモモードのため不可)
+              パスワード変更
+              {DemoBadge}
             </DropdownMenuItem>
           ) : (
             <DropdownMenuItem
@@ -161,7 +169,8 @@ export default function StaffCardMenu({
               className="cursor-not-allowed text-muted-foreground"
             >
               <Icons.Trash2 className="mr-2 size-4" />
-              削除（デモモードのため不可）
+              削除
+              {DemoBadge}
             </DropdownMenuItem>
           ) : (
             <DropdownMenuItem


### PR DESCRIPTION
## 概要
iPhone SE(375px)のデバイスで、スタッフ一覧のドロップダウンメニューを表示した際、プルダウンメニューの幅が大きすぎて圧迫感があるので修正した。

## 対応
- デモモードである状態コメントは変数DemoBadgeにspanタグとして保持しフォントサイズを9pxに変更
- デモモード時のメニュー項目を整理し保守性を向上

## 解決方法
コメント自体が大きすぎたため、フォントサイズを9pxに変更することによって
プルダウンメニューの幅を縮めることでき解決に至った。

## 設計理由
**デモモード時のメニュー項目を整理した理由**
同じ記述が３つ連続していたので可読性が悪いと判断して修正した。
`isDemo ? (<DropdownMenuItem > ...`が３つ連続でしていた。
その３つのメニュー項目を配列(menuItems)の抽出し、useMemoでメモ化した。
mapによるループ処理に統合しコードの重複を削減し可読性を高くした。


Closes #149