### PR TITLE
Fix/#150

### DIFF
--- a/src/app/(protected)/admin/staff/[staffId]/evaluation/components/evaluation-form.tsx
+++ b/src/app/(protected)/admin/staff/[staffId]/evaluation/components/evaluation-form.tsx
@@ -204,12 +204,15 @@ export default function EvaluationForm({
                   <EvaluationComments register={register} />
                 </>
               ) : existingEvaluations?.status === 'draft' ? (
-                <p className="flex items-center gap-2 text-muted-foreground justify-center p-4">
-                  <Icons.CircleAlert className="w-5 h-5" />
+                <p className="flex items-center text-xs sm:text-md gap-1 text-muted-foreground justify-center p-2 mt-8">
+                  <Icons.CircleAlert className="w-4 h-4" />
                   下書き保存中のため表示できません
                 </p>
               ) : (
-                <p>まだ評価が登録されていません</p>
+                <p className="flex items-center text-xs sm:text-md gap-1 text-muted-foreground justify-center p-2 mt-8">
+                  <Icons.CircleAlert className="w-4 h-4" />
+                  まだ評価が登録されていません
+                </p>
               )}
             </TabsContent>
             <TabsContent value="basic">

--- a/src/app/(protected)/admin/staff/[staffId]/evaluation/components/evaluation-form.tsx
+++ b/src/app/(protected)/admin/staff/[staffId]/evaluation/components/evaluation-form.tsx
@@ -15,6 +15,7 @@ import {
   EvaluationItemConstant,
   ExistingEvaluation,
   FormattedEvaluation,
+  TabType,
 } from '../../../../../../../../types/evaluations';
 import EvaluationComments from './evaluation-comments';
 import { useForm, useWatch } from 'react-hook-form';
@@ -30,6 +31,8 @@ import {
   Category,
 } from '../../../../../../../../types/evaluations';
 import Summary from './sumarry';
+import { useState } from 'react';
+import { isValidTab } from '@/lib/utils/evaluation-utils';
 
 const SECTION_TYPES: SectionType[] = ['basic', 'barista', 'cashier'];
 const CATEGORIES: Category[] = ['skill', 'hospitality', 'cleanliness'];
@@ -71,6 +74,14 @@ export default function EvaluationForm({
   baristaHospitalityItems,
   baristaCleanliness,
 }: EvaluationFormProps) {
+  const [isActive, setIsActive] = useState<TabType>('all');
+  const isSummaryViewWithoutData =
+    isActive === 'all' && existingEvaluations?.status !== 'completed';
+  const handleTabChange = (v: string) => {
+    if (isValidTab(v)) {
+      setIsActive(v);
+    }
+  };
   const {
     register,
     setValue,
@@ -169,7 +180,7 @@ export default function EvaluationForm({
       </CardHeader>
       <form onSubmit={handleSubmit(onSubmit)}>
         <CardContent className="mb-6">
-          <Tabs defaultValue="all">
+          <Tabs defaultValue="all" onValueChange={(v) => handleTabChange(v)}>
             <TabsList className="grid grid-cols-2 sm:grid-cols-4 h-auto w-full">
               <TabsTrigger
                 value="all"
@@ -247,18 +258,20 @@ export default function EvaluationForm({
             </TabsContent>
           </Tabs>
         </CardContent>
-        <CardFooter className="flex justify-around">
-          <Button
-            variant="secondary"
-            type="button"
-            onClick={saveDraftEvaluations}
-          >
-            下書き
-          </Button>
-          <Button variant="default" type="submit" disabled={isSubmitting}>
-            {isSubmitting ? <LoaderCircleIcon /> : '保存'}
-          </Button>
-        </CardFooter>
+        {isSummaryViewWithoutData ? null : (
+          <CardFooter className="flex justify-around">
+            <Button
+              variant="secondary"
+              type="button"
+              onClick={saveDraftEvaluations}
+            >
+              下書き
+            </Button>
+            <Button variant="default" type="submit" disabled={isSubmitting}>
+              {isSubmitting ? <LoaderCircleIcon /> : '保存'}
+            </Button>
+          </CardFooter>
+        )}
       </form>
     </Card>
   );

--- a/src/lib/utils/evaluation-utils.ts
+++ b/src/lib/utils/evaluation-utils.ts
@@ -3,6 +3,7 @@ import {
   EvaluationItem,
   ExistingEvaluationSection,
   SectionType,
+  TabType,
 } from '../../../types/evaluations';
 
 export const getSectionStats = (
@@ -46,4 +47,8 @@ export const isSectionType = (v: string): v is SectionType => {
 
 export const isCategoryType = (v: string): v is Category => {
   return ['skill', 'hospitality', 'cleanliness'].includes(v);
+};
+
+export const isValidTab = (v: string): v is TabType => {
+  return v === 'all' || isSectionType(v);
 };

--- a/types/evaluations.ts
+++ b/types/evaluations.ts
@@ -8,6 +8,8 @@ export type EvaluationItemConstant = Pick<
 
 export type SectionType = 'basic' | 'barista' | 'cashier';
 
+export type TabType = SectionType | 'all';
+
 export type Category = 'skill' | 'hospitality' | 'cleanliness';
 
 export type FormattedEvaluation = Record<SectionType, SectionData>;


### PR DESCRIPTION
## 概要
スタッフ評価ページの総合タブで未評価時のコメントレイアウト崩れ、下書き・保存ボタン誤表示を修正

## 解決策
総合タブの未評価時のコメントレイアウト崩れについてはフォント・アイコンサイズを修正することで解決した。
また、下書き・保存ボタン誤表示はタブが総合かつ評価のstatusがcompletedではないときに非表示にする。
タブの状態をuseStateで管理し、フラグを立てて条件分岐で制御した。

## 対応
- コメントのフォントサイズをtext-xs sm:text-mdへ変更
- アイコンのサイズをw-4 h-4へ変更
- isSummaryViewWithoutDataにactibveTab === 'all' && existingEvaluation?.status !== 'completed'の真偽値を変数として保持
- isSummaryViewWithoutDataをフラグにCardFooterの表示を切り替え

## 設計理由
**新たにType Guard関数(isValidTab)を追加作成した理由**
タブの状態を管理するためuseStateを使用した。
onValueChangeから渡ってくる値はstring型であるが、'all', 'basic', 'hospitality', 'cleanliness'の必要がある。
Type Guard関数(isValidTab)の引数にタブのdefaultValueを渡して検証することで担保とした。
またuseStateのジェネリクス引数にTabTypeを渡すことで初期値を記述する際にサジェストが効いたり、意図しない値を防ぎより堅牢にした。

Closes #150