### PR TITLE
Test/evalaution calc

### DIFF
--- a/src/lib/utils/evaluation-calc.test.ts
+++ b/src/lib/utils/evaluation-calc.test.ts
@@ -56,4 +56,22 @@ describe('calcRate', () => {
     const result = calcRate(input);
     expect(result).toEqual(expected);
   });
+  it('引数に空の配列を渡したとき各rateが0にフォールバックされる', () => {
+    const input: SectionScores[] = [];
+
+    const expected = {
+      skillScore: 0,
+      hospitalityScore: 0,
+      cleanlinessScore: 0,
+      skillRate: 0,
+      hospitalityRate: 0,
+      cleanlinessRate: 0,
+      totalScore: 0,
+      totalRate: 0,
+    };
+
+    const result = calcRate(input);
+
+    expect(result).toEqual(expected);
+  });
 });

--- a/src/lib/utils/evaluation-calc.test.ts
+++ b/src/lib/utils/evaluation-calc.test.ts
@@ -1,0 +1,11 @@
+import { calcRank } from './evaluation-calc';
+
+describe('calcRank', () => {
+  it('90以上はA', () => expect(calcRank(90)).toBe('A'));
+  it('89はB(境界値)', () => expect(calcRank(89)).toBe('B'));
+  it('70以上はB', () => expect(calcRank(70)).toBe('B'));
+  it('69はC(境界値)', () => expect(calcRank(69)).toBe('C'));
+  it('50はC', () => expect(calcRank(50)).toBe('C'));
+  it('49はD(境界値)', () => expect(calcRank(49)).toBe('D'));
+  it('0はD', () => expect(calcRank(0)).toBe('D'));
+});

--- a/src/lib/utils/evaluation-calc.test.ts
+++ b/src/lib/utils/evaluation-calc.test.ts
@@ -1,4 +1,9 @@
-import { calcRank, calcRate, SectionScores } from './evaluation-calc';
+import {
+  calcEvaluation,
+  calcRank,
+  calcRate,
+  SectionScores,
+} from './evaluation-calc';
 
 describe('calcRank', () => {
   it('90以上はA', () => expect(calcRank(90)).toBe('A'));
@@ -32,7 +37,7 @@ describe('calcRate', () => {
         cleanliness_max: 8,
       },
       {
-        section_type: 'basic',
+        section_type: 'cashier',
         skill_score: 6,
         skill_max: 8,
         hospitality_score: 4,
@@ -73,5 +78,71 @@ describe('calcRate', () => {
     const result = calcRate(input);
 
     expect(result).toEqual(expected);
+  });
+});
+
+describe('calcEvaluation', () => {
+  it('各セクションのrate・rank・各カテゴリrateが正しく計算されたsectionRatesが返ってくる', () => {
+    const sections: SectionScores[] = [
+      {
+        section_type: 'basic',
+        skill_score: 4,
+        skill_max: 8,
+        hospitality_score: 4,
+        hospitality_max: 8,
+        cleanliness_score: 6,
+        cleanliness_max: 8,
+      },
+      {
+        section_type: 'barista',
+        skill_score: 7,
+        skill_max: 8,
+        hospitality_score: 4,
+        hospitality_max: 8,
+        cleanliness_score: 7,
+        cleanliness_max: 8,
+      },
+      {
+        section_type: 'cashier',
+        skill_score: 6,
+        skill_max: 8,
+        hospitality_score: 4,
+        hospitality_max: 8,
+        cleanliness_score: 6,
+        cleanliness_max: 8,
+      },
+    ];
+
+    const expected = [
+      {
+        sectionType: 'basic',
+        rate: 58,
+        rank: 'C',
+        skillRate: 50,
+        hospitalityRate: 50,
+        cleanlinessRate: 75,
+      },
+      {
+        sectionType: 'barista',
+        rate: 75,
+        rank: 'B',
+        skillRate: 87,
+        hospitalityRate: 50,
+        cleanlinessRate: 87,
+      },
+      {
+        sectionType: 'cashier',
+        rate: 66,
+        rank: 'C',
+        skillRate: 75,
+        hospitalityRate: 50,
+        cleanlinessRate: 75,
+      },
+    ];
+
+    const result = calcEvaluation(sections);
+
+    expect(result.sectionRates).toEqual(expected);
+    expect(result.sectionRates).toHaveLength(3);
   });
 });

--- a/src/lib/utils/evaluation-calc.test.ts
+++ b/src/lib/utils/evaluation-calc.test.ts
@@ -1,4 +1,4 @@
-import { calcRank } from './evaluation-calc';
+import { calcRank, calcRate, SectionScores } from './evaluation-calc';
 
 describe('calcRank', () => {
   it('90以上はA', () => expect(calcRank(90)).toBe('A'));
@@ -8,4 +8,52 @@ describe('calcRank', () => {
   it('50はC', () => expect(calcRank(50)).toBe('C'));
   it('49はD(境界値)', () => expect(calcRank(49)).toBe('D'));
   it('0はD', () => expect(calcRank(0)).toBe('D'));
+});
+
+describe('calcRate', () => {
+  it('複数セクションのスコアが正しく合算され、各カテゴリのrateが計算される', () => {
+    const input: SectionScores[] = [
+      {
+        section_type: 'basic',
+        skill_score: 4,
+        skill_max: 8,
+        hospitality_score: 4,
+        hospitality_max: 8,
+        cleanliness_score: 6,
+        cleanliness_max: 8,
+      },
+      {
+        section_type: 'barista',
+        skill_score: 7,
+        skill_max: 8,
+        hospitality_score: 4,
+        hospitality_max: 8,
+        cleanliness_score: 7,
+        cleanliness_max: 8,
+      },
+      {
+        section_type: 'basic',
+        skill_score: 6,
+        skill_max: 8,
+        hospitality_score: 4,
+        hospitality_max: 8,
+        cleanliness_score: 6,
+        cleanliness_max: 8,
+      },
+    ];
+
+    const expected = {
+      skillScore: 17,
+      hospitalityScore: 12,
+      cleanlinessScore: 19,
+      skillRate: 70,
+      hospitalityRate: 50,
+      cleanlinessRate: 79,
+      totalScore: 48,
+      totalRate: 66,
+    };
+
+    const result = calcRate(input);
+    expect(result).toEqual(expected);
+  });
 });

--- a/src/lib/utils/evaluation-calc.ts
+++ b/src/lib/utils/evaluation-calc.ts
@@ -1,6 +1,6 @@
 import { SectionType } from '../../../types/evaluations';
 
-type SectionScores = {
+export type SectionScores = {
   section_type: SectionType;
   skill_score: number;
   skill_max: number;


### PR DESCRIPTION
## 概要
evaluation-calc.tsの単体テスト

## 対応
### 5月14日
- calcRankの境界値テスト
- calcRateの各セクションのスコア合算・rateの計算がされるテストを追加

### 5月15日
- calcEvaluationのテスト, 引数に空の配列(評価者0人)を渡したとき各rateが0にフォールバックされるテストを実装

### 5月16日
- 各セクションのrate, rank, 各カテゴリrateが正しく計算されたsectionRatesが返ってくるテストを実装

## 設計理由
**今回のテストの必要性**
- calcRank
  `>= 90 / >= 70 / >= 50` の条件分岐は境界値でバグが潜みやすい。
  境界値（90, 89, 70, 69, 50, 49, 0）を網羅し、
  各ランクが正しく返ることを保証した。

- calcRate
basic / barista / cashier の各セクションスコアが
reduceで正しく合算されることを保証した。
また空の配列が渡された場合、reduceの初期値が0になるためreateの計算が 0 / 0 = NaN となるリスクがある。
フォールバック処理が正しく機能し、各reateが0になることを保証した。

- calcEvaluation
- calcEvaluation
  calcRate と calcRank を組み合わせて生成される sectionRates が、
  各セクション（basic / barista / cashier）の rate・rank・
  skill / hospitality / cleanliness を正しく含む構造になっているか保証した。
  また sectionRates の件数が sections と一致することを保証し、
  map による全件処理が正しく機能していることを担保した。


