### PR TITLE
Perf/158 parallelize server queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "db:migrate": "supabase migration up && npm run db:types",
     "db:reset": "supabase db reset && npm run db:types",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "preview": "next build && next start",
+    "preview:all": "supabase start && next build && next start"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",

--- a/src/app/(protected)/admin/page.tsx
+++ b/src/app/(protected)/admin/page.tsx
@@ -17,18 +17,22 @@ export default async function AdminPage() {
 
   const { orgId, profile } = await requireAdmin(supabase);
 
-  const { data: staffs, error: staffError } = await supabase
-    .from('profiles')
-    .select('id, name, role, store_name, avatar_url, email')
-    .eq('organization_id', orgId)
-    .eq('role', 'staff');
+  const [
+    { data: staffs, error: staffError },
+    { data: evaluationPeriods, error: periodsError },
+  ] = await Promise.all([
+    supabase
+      .from('profiles')
+      .select('id, name, role, store_name, avatar_url, email')
+      .eq('organization_id', orgId)
+      .eq('role', 'staff'),
+    supabase
+      .from('evaluation_periods')
+      .select('id, name, is_current')
+      .eq('organization_id', orgId),
+  ]);
+
   if (staffError) redirect('/admin');
-
-  const { data: evaluationPeriods, error: periodsError } = await supabase
-    .from('evaluation_periods')
-    .select('id, name, is_current')
-    .eq('organization_id', orgId);
-
   if (periodsError || !evaluationPeriods) return;
 
   const currentEvaluationPeriod = evaluationPeriods.find(

--- a/src/app/(protected)/admin/staff/[staffId]/evaluation/page.tsx
+++ b/src/app/(protected)/admin/staff/[staffId]/evaluation/page.tsx
@@ -34,49 +34,56 @@ export default async function EvaluationPage({
 
   const { orgId } = await requireAdmin(supabase);
 
-  const { data: staffProfile, error: staffProfileError } = await supabase
-    .from('profiles')
-    .select('name, store_name, role, email, avatar_url')
-    .eq('organization_id', orgId)
-    .eq('id', staffId)
-    .single();
-  if (staffProfileError) throw new Error('スタッフ情報の取得に失敗しました');
-
-  //初回評価時はデータが存在しないためnullになるケースがある
-  //.single()はデータが存在しない場合もerrorを返すため意図的にerrorを無視している
-  const { data: existingEvaluation } = (await supabase
-    .from('evaluations')
-    .select(
-      `
+  const [
+    { data: staffProfile, error: staffProfileError },
+    existingEvaluationResult,
+  ] = await Promise.all([
+    supabase
+      .from('profiles')
+      .select('name, store_name, role, email, avatar_url')
+      .eq('organization_id', orgId)
+      .eq('id', staffId)
+      .single(),
+    supabase
+      .from('evaluations')
+      .select(
+        `
         id,
         status,
         action_plan,
         total_comment,
         future_vision,
-            evaluation_sections (
-            id,
-            section_type,
-            good_points,
-            improvement_points,
-            skill_score,
-            skill_max,
-            hospitality_score,
-            hospitality_max,
-            cleanliness_score,
-            cleanliness_max,
-              evaluation_items (
-                item_name,
-                category,
-                score
-          )
-        )
-      `
-    )
-    .eq('staff_id', staffId)
-    .eq('evaluation_period_id', periodId)
-    .eq('organization_id', orgId)
-    //DBのCHECK制約によりsection_typeはSectionTypeのいずれかであることが保証されている
-    .single()) as { data: ExistingEvaluation | null; error: unknown };
+        evaluation_sections (
+          id,
+          section_type,
+          good_points,
+          improvement_points,
+          skill_score,
+          skill_max,
+          hospitality_score,
+          hospitality_max,
+          cleanliness_score,
+          cleanliness_max,
+          evaluation_items (
+            item_name,
+            category,
+            score
+            )
+            )
+            `
+      )
+      .eq('staff_id', staffId)
+      .eq('evaluation_period_id', periodId)
+      .eq('organization_id', orgId)
+      .single(),
+  ]);
+
+  const { data: existingEvaluation } = existingEvaluationResult as {
+    data: ExistingEvaluation | null;
+    error: unknown;
+  };
+
+  if (staffProfileError) throw new Error('スタッフ情報の取得に失敗しました');
 
   const formattedEvaluationData = existingEvaluation
     ? formatEvaluationData(existingEvaluation)

--- a/src/app/(protected)/admin/staff/[staffId]/page.tsx
+++ b/src/app/(protected)/admin/staff/[staffId]/page.tsx
@@ -25,21 +25,56 @@ export default async function StaffDetailPage({
 
   const { orgId, profile } = await requireAdmin(supabase);
 
-  const { data: targetStaff, error: targetStaffError } = await supabase
-    .from('profiles')
-    .select('name, store_name, role, email, avatar_url')
-    .eq('id', staffId)
-    .eq('organization_id', orgId)
-    .single();
-  if (targetStaffError || !targetStaff) redirect('/admin/staff');
+  const [
+    { data: targetStaff, error: targetStaffError },
+    { data: selectedPeriod, error },
+    chartRawResult,
+  ] = await Promise.all([
+    supabase
+      .from('profiles')
+      .select('name, store_name, role, email, avatar_url')
+      .eq('id', staffId)
+      .eq('organization_id', orgId)
+      .single(),
+    supabase
+      .from('evaluation_periods')
+      .select('id, name')
+      .eq('organization_id', orgId)
+      .eq('is_current', true)
+      .maybeSingle(),
+    supabase
+      .from('evaluation_periods')
+      .select(
+        `
+        id, name,
+        evaluations!inner (
+          evaluation_sections (
+            section_type,
+            skill_score,
+            skill_max,
+            hospitality_score,
+            hospitality_max,
+            cleanliness_score,
+            cleanliness_max
+          )
+        )
+        `
+      )
+      .eq('organization_id', orgId)
+      .eq('evaluations.staff_id', staffId)
+      .order('created_at', { ascending: true })
+      .limit(4),
+  ]);
 
-  const { data: selectedPeriod, error } = await supabase
-    .from('evaluation_periods')
-    .select('id, name')
-    .eq('organization_id', orgId)
-    .eq('is_current', true)
-    .maybeSingle();
+  if (targetStaffError || !targetStaff) redirect('/admin/staff');
   if (error) throw new Error('評価期間の取得に失敗しました');
+
+  const { data } = chartRawResult as {
+    data: PeriodForChart[] | null;
+    error: unknown;
+  };
+
+  const chartData = formatChartData(data ?? []);
 
   const { data: targetEvaluation } = selectedPeriod
     ? ((await supabase
@@ -75,31 +110,6 @@ export default async function StaffDetailPage({
         .eq('organization_id', orgId)
         .single()) as { data: ExistingEvaluation | null; error: unknown })
     : { data: null };
-
-  const { data } = (await supabase
-    .from('evaluation_periods')
-    .select(
-      `
-      id, name,
-      evaluations!inner (
-        evaluation_sections (
-          section_type,
-          skill_score,
-          skill_max,
-          hospitality_score,
-          hospitality_max,
-          cleanliness_score,
-          cleanliness_max
-        )
-      )
-      `
-    )
-    .eq('organization_id', orgId)
-    .eq('evaluations.staff_id', staffId)
-    .order('created_at', { ascending: true })
-    .limit(4)) as { data: PeriodForChart[] | null; error: unknown };
-
-  const chartData = formatChartData(data ?? []);
 
   return (
     <AdminContainer>

--- a/src/app/(protected)/admin/staff/page.tsx
+++ b/src/app/(protected)/admin/staff/page.tsx
@@ -14,21 +14,24 @@ export default async function StaffManagementPage() {
 
   const { orgId, profile } = await requireAdmin(supabase);
 
-  const { data: staffs, error: staffsError } = await supabase
-    .from('profiles')
-    .select('id, name, role, store_name, avatar_url, email')
-    .eq('organization_id', orgId)
-    .eq('role', 'staff');
+  const [
+    { data: staffs, error: staffsError },
+    { data: selectedPeriod, error: selectedPeriodError },
+  ] = await Promise.all([
+    supabase
+      .from('profiles')
+      .select('id, name, role, store_name, avatar_url, email')
+      .eq('organization_id', orgId)
+      .eq('role', 'staff'),
+    supabase
+      .from('evaluation_periods')
+      .select('id')
+      .eq('organization_id', orgId)
+      .eq('is_current', true)
+      .maybeSingle(),
+  ]);
 
   if (staffsError) redirect('/admin');
-
-  const { data: selectedPeriod, error: selectedPeriodError } = await supabase
-    .from('evaluation_periods')
-    .select('id')
-    .eq('organization_id', orgId)
-    .eq('is_current', true)
-    .maybeSingle();
-
   if (selectedPeriodError) redirect('/admin');
 
   const { data: existingEvaluations, error: exisgintError } = selectedPeriod


### PR DESCRIPTION
## 概要
admin/page.tsxのクエリが直列実行になっており、不要な待機が発生しているので修正する

## 対応
- パフォーマンス計測用のビルドコマンドをpackage.jsonに追加
- profilesとevaluation_periodsの非同期処理をPromise.allで並列化 
- スタッフ一覧ページのprofiles, evaluation_periods取得の非同期処理を並列化
- スタッフ詳細ページでprofiles, evaluation_periods, 評価履歴取得の非同期処理を並列化
- スタッフ評価ページでstaffProfile, existingEvalluation取得の非同期処理を並列化

## 設計理由
- staffsとevaluationPeriodsはorgIdに依存するが互いに依存関係がない
- Promise.allSetteledではなくPromise.allを選択。
どちらかが失敗した場合に画面を表示する意味がないため、片方が失敗したら即座にエラーにする方が適切と判断した。
 
## 計測結果
### 計測条件
- 環境: ローカル本番ビルド(next build && next start)
- 計測方法: console.timeで10回計測の中央値

### 検証結果

#### app/admin/page.tsx
| | Before | After | 改善幅 |
| --- | --- | --- | --- |
| queries(console.time) | 10.72ms | 4.832ms | 約55%短縮 |
| TTFB(Networkタブ) | 108.72ms | 112.51ms | 誤差範囲内 |
| TTFB 本番 | 1.17s | 1.265s | 誤差範囲内 |

#### 考察
ローカル環境ではクエリ自体が高速なため、TTFBの改善幅(約6ms)が
計測ブレ(92ms〜131ms、約40ms幅)の範囲内に収まり、
ブラウザ計測では効果を確認できなかった。
ただしサーバー側のクエリ実行時間は約55%短縮されており、
本番環境ではVercel〜Supabase間のネットワーク遅延が加わるため、
より顕著な改善が期待できる。

#### app/admin/staff/page.tsx
| |Before | After | 改善幅 |
| --- | --- | --- | --- |
| queries(console.time) | 10.47ms | 4.782ms | 54%短縮 |
| TTFB 本番 | 1.58s | 1.145s | 約28%短縮 |

#### 考察
app/admin/page.tsxと同じ原因。
サーバー側のクエリ実行時間は54%短縮されており、
本番環境では改善が期待できる。

#### app/admin/setting/page.tsx
並列化できるクエリなし。対象外。

#### app/admin/staff/[staffId]/page.tsx
| | Before | After | 改善幅 |
| --- | --- | --- | --- |
| query1 + query2 | 66.58ms | 24.336ms | 約63%短縮 | 
| TTFB 本番 | 1.135s | 1.14s | 誤差範囲内 |

#### 考察
profiles, evaluation_periods, 評価履歴用evaluation_periodsの3クエリが直列になっていた。
targetEvalautionはselectPeriodに依存するため並列化できないが、それ以外の3クエリをPromise.allで並列化した結果、約63%短縮された。
本番環境ではネットワーク遅延が加わるためより顕著な改善が期待できる。

#### 設計メモ
評価履歴用evaluation_periodsはPromise.allに未解決Promiseとして渡すため、awaitする前の段階ではasによる型キャストができない。そのためPromise.all完了後に変数で受け取ってからasでキャストした。

#### app/admin/staff/[staffId]/evaluation/page.tsx
| | Before | After | 改善幅 |
| --- | --- | --- | --- |
| query | 17.929ms | 11.085ms | 約38%短縮 |
| TTFB 本番 | 1.29s | 1.16s | 約10%短縮 |

#### 考察
staffProfile, existingEvaluationが直列になっており、その部分をPromise.allで並列化した結果、約38%短縮された。
本番環境ではネットワーク遅延が加わるためより顕著な改善が期待できる。

#### 設計メモ
existingEvaluationはPromise.allに未解決Promiseとして渡すため、awaitする前の段階ではasにより型キャストができない。そのためPromise.all完了後に変数で受け取ってからasでキャストした。
他の箇所に比べ短縮率が低い原因は、exisitngEvaluationのネストが深いJOINクエリのためである。
ボトルネックになっており他の対処法を考える。

### 総合考察
ローカル環境ではサーバー側のクエリ実行時間を38〜63%短縮を確認。
本番環境ではadmin/staffで約28%のTTFB改善が見られた一方、
一部ページでは誤差範囲内にとどまった。

### リージョンを東京へ変更した結果

#### 背景
本番環境でTTFBがローカルに比べて顕著に遅い原因を調査したところ、
VercelのFunction RegionがWashington D.C.(us-east-1)、
Supabaseが東京(ap-northeast-1)になっていた。

つまり以下のような通信経路でクエリのたびに太平洋を2往復していた。
- 日本(ブラウザ) → アメリカ(Vercel) リクエスト送信
- アメリカ(Vercel) → 日本(Supabase) データ取得
- 日本(Supabase) → アメリカ(Vercel) → 日本(ブラウザ) 返却

#### 対応
VercelのFunction Regionを東京(ap-northeast-1)に変更し再デプロイ。

#### 計測結果
| ページ | 変更前 | 変更後 | 改善幅 |
| --- | --- | --- | --- |
| /admin | 1.265s | 722.85ms | 約43%短縮 |
| /admin/staff | 1.145s | 512.11ms | 約55%短縮 |
| /admin/staff/[staffId] | 1.14s | 653.60ms | 約43%短縮 |
| /admin/staff/[staffId]/evaluation | 1.16s | 539.87ms | 約53%短縮 |

#### 考察
全ページで約半分のTTFBに短縮された。
Promise.allによるクエリ並列化と合わせて、本番環境のレスポンス時間を
大幅に改善することができた。

パフォーマンス改善においてコード最適化だけでなく、
インフラのリージョン設定もボトルネックになり得ることを学んだ。

Closes #158