### PR TITLE
fix: デモログインのプリフェッチによるクッキー再セットを防止

### DIFF
--- a/src/app/(landing)/components/demo-login-button.tsx
+++ b/src/app/(landing)/components/demo-login-button.tsx
@@ -1,0 +1,12 @@
+import { loginAsDemo } from '@/app/_actions/demo-login';
+import { Button } from '@/components/ui/button';
+
+export default function DemoLoginButton() {
+  return (
+    <form action={loginAsDemo}>
+      <Button type="submit" size="lg">
+        デモを試す
+      </Button>
+    </form>
+  );
+}

--- a/src/app/(landing)/components/hero.tsx
+++ b/src/app/(landing)/components/hero.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 
 import { Button } from '@/components/ui/button';
 import Container from '@/components/shared/contaienr';
+import DemoLoginButton from './demo-login-button';
 
 export default function Hero() {
   return (
@@ -26,9 +27,8 @@ export default function Hero() {
               </p>
             </div>
             <div className="flex flex-col gap-4 md:flex-row md:justify-center sm:gap-8 md:gap-12">
-              <Button size="lg" asChild>
-                <Link href="/demo">デモで今すぐ試す</Link>
-              </Button>
+              <DemoLoginButton />
+
               <Button size="lg" variant="outline" asChild>
                 <Link href="/signup">無料ではじめる</Link>
               </Button>

--- a/src/app/_actions/demo-login.ts
+++ b/src/app/_actions/demo-login.ts
@@ -1,15 +1,14 @@
+'use server';
+
 import { createClient } from '@/lib/supabase/server';
-import { NextResponse } from 'next/server';
+import { redirect } from 'next/navigation';
 
-export async function GET() {
+export async function loginAsDemo() {
   const supabase = await createClient();
-
   await supabase.auth.signInWithPassword({
     email: process.env.DEMO_EMAIL!,
     password: process.env.DEMO_PASSWORD!,
   });
 
-  return NextResponse.redirect(
-    new URL('/admin', process.env.NEXT_PUBLIC_SITE_URL!)
-  );
+  redirect('/admin');
 }


### PR DESCRIPTION
## 概要
`/demo` ルートでログイン後、ログアウト処理を実行するとクッキーは正しく削除される。しかしランディングページ(`/`)に移動すると、ユーザーがなにも操作していないにも関わらずクッキーが再び埋め込まれ、デモユーザーの状態が復活してしまう。

## 原因
ランディングページに設置した `<Link href="/demo">` が Next.js の自動プリフェッチによって `GET /demo` を発火させていた。

`/demo` は Route Handler で `signInWithPassword` を実行する副作用を持っているため、プリフェッチだけでデモユーザーのクッキーがセットされてしまう。
なお、ローカル(`next dev`)では `<Link>` の自動プリフェッチが無効化されているため、この問題は本番ビルドでのみ再現する。

## 対応
- Server Actions でデモログインを実装
- ランディングページの `<Link>` を `<form>` + `<button>` に変更

## 設計理由

**`<form>` を採用した理由**
`<form>` 要素は Next.js のプリフェッチ対象外。プリフェッチによる意図しない副作用の発火を構造的に防げる。`<Link prefetch={false}>` でも解決できたが、副作用を持つエンドポイントを GET で公開し続けるのは HTTP の原則に反しており、他の箇所からリンクされた際に再発するリスクがあるため見送った。

**Server Actions を採用した理由**
`<form>` を採用する以上、送信先で認証処理を実行する必要がある。`/demo` をページ化して Server Component で実装する案もあったが、ランディング → デモページ → ボタン押下の2クリックが必要になり UX が低下する。ランディングから直接呼び出せる Server Actions が最も適切と判断した。

Closes #167