### PR TITLE
Feat/lp scroll animation

### DIFF
--- a/src/app/(landing)/components/call-to-action.tsx
+++ b/src/app/(landing)/components/call-to-action.tsx
@@ -17,7 +17,7 @@ export default function CallToAction() {
             デモモードでは、アカウントを登録せずにアプリを利用できます
           </p>
           <div className="flex justify-center">
-            <DemoLoginButton />
+            <DemoLoginButton className="text-base sm:text-lg md:text-xl py-5 md:py-6 lg:py-7 md:w-lg" />
           </div>
         </div>
       </Container>

--- a/src/app/(landing)/components/call-to-action.tsx
+++ b/src/app/(landing)/components/call-to-action.tsx
@@ -2,24 +2,22 @@ import Link from 'next/link';
 
 import { Button } from '@/components/ui/button';
 import Container from '@/components/shared/contaienr';
-import SectionTitle from './section-title';
+import DemoLoginButton from './demo-login-button';
 
 export default function CallToAction() {
   return (
     <section>
       <Container>
-        <div className="text-center">
-          <SectionTitle>今すぐGrowth Finderを体験</SectionTitle>
-          <p className="text-lg text-muted-foreground mb-8">
+        <div className="text-center space-y-10 md:space-y-12 lg:space-y-16">
+          <p className="font-bold text-2xl sm:text-3xl md:text-5xl lg:text-6xl">
+            今すぐ<span className="text-primary">Growth Finder</span>
+            を体験
+          </p>
+          <p className="text-sm sm:text-base md:text-lg lg:text-xl text-muted-foreground">
             デモモードでは、アカウントを登録せずにアプリを利用できます
           </p>
-          <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Button size="lg" asChild>
-              <Link href="/demo">デモで今すぐ試す</Link>
-            </Button>
-            <Button size="lg" variant="outline" asChild>
-              <Link href="/signup">無料ではじめる</Link>
-            </Button>
+          <div className="flex justify-center">
+            <DemoLoginButton />
           </div>
         </div>
       </Container>

--- a/src/app/(landing)/components/call-to-action.tsx
+++ b/src/app/(landing)/components/call-to-action.tsx
@@ -1,6 +1,3 @@
-import Link from 'next/link';
-
-import { Button } from '@/components/ui/button';
 import Container from '@/components/shared/contaienr';
 import DemoLoginButton from './demo-login-button';
 

--- a/src/app/(landing)/components/demo-login-button.tsx
+++ b/src/app/(landing)/components/demo-login-button.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 export default function DemoLoginButton() {
   return (
     <form action={loginAsDemo}>
-      <Button type="submit" size="lg">
+      <Button type="submit" className="w-50 md:w-96 rounded-4xl">
         デモを試す
       </Button>
     </form>

--- a/src/app/(landing)/components/demo-login-button.tsx
+++ b/src/app/(landing)/components/demo-login-button.tsx
@@ -1,10 +1,14 @@
 import { loginAsDemo } from '@/app/_actions/demo-login';
 import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
 
-export default function DemoLoginButton() {
+export default function DemoLoginButton({ className }: { className?: string }) {
   return (
     <form action={loginAsDemo}>
-      <Button type="submit" className="w-50 md:w-96 rounded-4xl">
+      <Button
+        type="submit"
+        className={cn('w-50 md:w-96 rounded-4xl', className)}
+      >
         デモを試す
       </Button>
     </form>

--- a/src/app/(landing)/components/fade-in.tsx
+++ b/src/app/(landing)/components/fade-in.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { cn } from '@/lib/utils';
+
+type FadeInProps = {
+  children: React.ReactNode;
+  className?: string;
+  delay: number;
+};
+
+export default function FadeIn({
+  children,
+  className,
+  delay = 0,
+}: FadeInProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+          observer.unobserve(entry.target);
+        }
+      },
+      { threshold: 0.15, rootMargin: '0px 0px -10% 0px' }
+    );
+
+    observer.observe(element);
+
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div
+      ref={ref}
+      style={{ transitionDelay: `${delay}s` }}
+      className={cn(
+        'transition-all duration-700 ease-out motion-reduce:transition-none',
+        isVisible
+          ? 'opacity-100 translate-y-0'
+          : 'opacity-0 translate-y-8 motion-reduce:opacity-100 motion-reduce:translate-y-0',
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/app/(landing)/components/fade-in.tsx
+++ b/src/app/(landing)/components/fade-in.tsx
@@ -41,10 +41,10 @@ export default function FadeIn({
       ref={ref}
       style={{ transitionDelay: `${delay}s` }}
       className={cn(
-        'transition-all duration-700 ease-out motion-reduce:transition-none',
         isVisible
-          ? 'opacity-100 translate-y-0'
-          : 'opacity-0 translate-y-8 motion-reduce:opacity-100 motion-reduce:translate-y-0',
+          ? 'animate-in fade-in slide-in-from-bottom-8 duration-700 fill-mode-both'
+          : 'opacity-0',
+        'motion-reduce:animate-none motion-reduce:opacity-100',
         className
       )}
     >

--- a/src/app/(landing)/components/hero.tsx
+++ b/src/app/(landing)/components/hero.tsx
@@ -6,7 +6,7 @@ import { Icons } from '@/components/icon/icons';
 
 export default function Hero() {
   return (
-    <section className="min-h-screen flex items-center pt-20 lg:pt-8">
+    <section className="relative min-h-screen flex items-center pt-20 lg:pt-8">
       <Container>
         <div className="flex flex-col md:flex-row items-center gap-8">
           <div className="flex flex-col gap-8 items-center md:flex-1">
@@ -72,6 +72,10 @@ export default function Hero() {
           </div>
         </div>
       </Container>
+      <div className="absolute bottom-3 md:bottom-10 left-1/2 -translate-x-1/2 flex flex-col items-center animate-bounce-gentle">
+        <Icons.TbArrowBigDownLinesFilled className="w-5 h-5 text-muted-foreground" />
+        <p className="mt-3 text-xs text-muted-foreground">Scroll</p>
+      </div>
     </section>
   );
 }

--- a/src/app/(landing)/components/hero.tsx
+++ b/src/app/(landing)/components/hero.tsx
@@ -8,8 +8,8 @@ export default function Hero() {
   return (
     <section className="min-h-screen flex items-center pt-20 lg:pt-8">
       <Container>
-        <div className="flex flex-col md:flex-row items-center gap-5">
-          <div className="flex flex-col gap-3 items-center md:flex-1">
+        <div className="flex flex-col md:flex-row items-center gap-8">
+          <div className="flex flex-col gap-8 items-center md:flex-1">
             <div className="flex flex-col gap-4 lg:gap-8">
               <p className="text-left font-bold text-2xl md:text-3xl lg:text-5xl">
                 スタッフ評価の
@@ -24,7 +24,7 @@ export default function Hero() {
               </p>
             </div>
 
-            <div className="flex flex-col items-center gap-5">
+            <div className="flex flex-col items-center gap-8">
               <ul className="flex gap-3 md:gap-8 xl:gap-20">
                 <li className="flex flex-col items-center gap-2">
                   <div className="flex justify-center items-center w-12 md:w-18 lg:w-28 h-12 md:h-18 lg:h-28 bg-white rounded-full shadow-xs">
@@ -58,7 +58,7 @@ export default function Hero() {
                 </li>
               </ul>
 
-              <DemoLoginButton />
+              <DemoLoginButton className="text-base sm:text-lg md:text-xl py-4 md:py-5 lg:py-6 md:w-lg" />
             </div>
           </div>
           <div className="md:flex-1">

--- a/src/app/(landing)/components/hero.tsx
+++ b/src/app/(landing)/components/hero.tsx
@@ -36,7 +36,7 @@ export default function Hero() {
           </div>
           <div className="lg:flex-1">
             <Image
-              src="/images/growth-finder-main.png"
+              src="/images/growth-finder-main-a.png"
               alt="Growth Finder ダッシュボード画像"
               width={800}
               height={500}

--- a/src/app/(landing)/components/hero.tsx
+++ b/src/app/(landing)/components/hero.tsx
@@ -1,46 +1,72 @@
 import Image from 'next/image';
-import Link from 'next/link';
 
-import { Button } from '@/components/ui/button';
 import Container from '@/components/shared/contaienr';
 import DemoLoginButton from './demo-login-button';
+import { Icons } from '@/components/icon/icons';
 
 export default function Hero() {
   return (
-    <section className="min-h-screen flex items-center pt-32 lg:pt-10">
+    <section className="min-h-screen flex items-center pt-20 lg:pt-8">
       <Container>
-        <div className="flex flex-col lg:flex-row items-center gap-12">
-          <div className="flex flex-col gap-8 lg:flex-1 text-center md:text-center">
-            <h1 className="font-bold text-3xl sm:text-5xl md:text-7xl">
-              Growth Finder
-            </h1>
-            <div className="text-center">
-              <p className="text-base mb-6 sm:text-2xl md:text-3xl">
-                スタッフの成長を可視化する
-                <br />
-                評価ツール
+        <div className="flex flex-col md:flex-row items-center gap-5">
+          <div className="flex flex-col gap-3 items-center md:flex-1">
+            <div className="flex flex-col gap-4 lg:gap-8">
+              <p className="text-left font-bold text-2xl md:text-3xl lg:text-5xl">
+                スタッフ評価の
               </p>
-              <p className="text-base sm:text-2xl md:text-3xl text-muted-foreground">
-                現場の課題から作った
+              <p className="text-left font-bold text-4xl md:text-5xl lg:text-6xl text-primary">
+                属人化をなくす
+              </p>
+              <p className="text-left text-xl md:text-2xl lg:text-3xl">
+                誰が評価しても同じ基準で
                 <br />
-                手書き評価ツールをデジタル化
+                スタッフの成長を可視化
               </p>
             </div>
-            <div className="flex flex-col gap-4 md:flex-row md:justify-center sm:gap-8 md:gap-12">
-              <DemoLoginButton />
 
-              <Button size="lg" variant="outline" asChild>
-                <Link href="/signup">無料ではじめる</Link>
-              </Button>
+            <div className="flex flex-col items-center gap-5">
+              <ul className="flex gap-3 md:gap-8 xl:gap-20">
+                <li className="flex flex-col items-center gap-2">
+                  <div className="flex justify-center items-center w-12 md:w-18 lg:w-28 h-12 md:h-18 lg:h-28 bg-white rounded-full shadow-xs">
+                    <Icons.MessageSquareText className="w-5 md:w-8 lg:w-14 h-5 md:h-8 lg:h-14 text-primary" />
+                  </div>
+                  <p className="text-xs md:text-sm xl:text-lg font-bold">
+                    面談の記録を
+                    <br />
+                    かんたんに
+                  </p>
+                </li>
+                <li className="flex flex-col items-center gap-2">
+                  <div className="flex justify-center items-center w-12 md:w-18 lg:w-28 h-12 md:h-18 lg:h-28 bg-white rounded-full shadow-xs">
+                    <Icons.ChartColumnIncreasing className="w-5 md:w-8 lg:w-14 h-5 md:h-8 lg:h-14 text-primary" />
+                  </div>
+                  <p className="text-xs md:text-sm xl:text-lg font-bold">
+                    成長状況を
+                    <br />
+                    グラフで可視化
+                  </p>
+                </li>
+                <li className="flex flex-col items-center gap-2">
+                  <div className="flex justify-center items-center w-12 md:w-18 lg:w-28 h-12 md:h-18 lg:h-28 bg-white rounded-full shadow-xs">
+                    <Icons.ClipboardList className="w-5 md:w-8 lg:w-14 h-5 md:h-8 lg:h-14 text-primary" />
+                  </div>
+                  <p className="text-xs md:text-sm xl:text-lg font-bold">
+                    評価基準を統一
+                    <br />
+                    育成の質を向上
+                  </p>
+                </li>
+              </ul>
+
+              <DemoLoginButton />
             </div>
           </div>
-          <div className="lg:flex-1">
+          <div className="md:flex-1">
             <Image
-              src="/images/growth-finder-main-a.png"
+              src="/images/growth-finder-main.png"
               alt="Growth Finder ダッシュボード画像"
               width={800}
-              height={500}
-              className="rounded-lg shadow-xl border"
+              height={600}
               priority
             />
           </div>

--- a/src/app/(landing)/components/problem-solution.tsx
+++ b/src/app/(landing)/components/problem-solution.tsx
@@ -2,20 +2,100 @@ import SectionTitle from './section-title';
 import Container from '@/components/shared/contaienr';
 import { Icons } from '@/components/icon/icons';
 import Image from 'next/image';
+import { cn } from '@/lib/utils';
+
+const items = [
+  {
+    problem: 'うまくコミュニケーションがとれない',
+    solution: 'コミュニケーションの質が向上します',
+    problemIcon: '/images/problem-icon1.png',
+    solutionIcon: '/images/solution-icon2.png',
+  },
+  {
+    problem: 'スタッフの成長が見えにくい',
+    solution: '成長具合が可視化され伸びしろが明確に',
+    problemIcon: '/images/problem-icon2.png',
+    solutionIcon: '/images/solution-icon3.png',
+  },
+  {
+    problem: '評価ツールが紙で管理が大変',
+    solution: '評価履歴をすぐに確認できて便利',
+    problemIcon: '/images/problem-icon3.png',
+    solutionIcon: '/images/solution-icon1.png',
+  },
+];
 
 export default function ProblemSolution() {
   return (
     <section id="problem-solution" className="scroll-mt-24">
-      <Container>
+      <Container className="space-y-20">
         <SectionTitle>
           こんな
-          <span className="text-2xl md:text-4xl font-bold text-primary">
-            お悩み
-          </span>
+          <span className="font-bold text-primary">お悩み</span>
           ありませんか？
         </SectionTitle>
-        
+
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+          {items.map((item) => (
+            <Card
+              text={item.problem}
+              key={item.problem}
+              icon={item.problemIcon}
+              variant="problem"
+            />
+          ))}
+        </div>
+
+        <div className="space-y-5">
+          <div className="flex justify-center text-primary">
+            <Icons.ArrowBigDown className="w-20 h-20" />
+          </div>
+
+          <div className="text-2xl md:text-4xl font-bold text-center">
+            <span className="font-bold text-primary">Growth Finder</span>
+            が解決します
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+          {items.map((item) => (
+            <Card
+              text={item.solution}
+              key={item.solution}
+              icon={item.solutionIcon}
+              variant="solution"
+            />
+          ))}
+        </div>
       </Container>
     </section>
+  );
+}
+
+function Card({
+  text,
+  icon,
+  variant,
+}: {
+  text: string;
+  icon: string;
+  variant: 'problem' | 'solution';
+}) {
+  const isProblem = variant === 'problem';
+  return (
+    <div className="flex flex-col items-center gap-5 p-8 shadow-2xl bg-primary-foreground rounded-xl">
+      <span
+        className={cn(
+          'text-xs font-bold px-3 py-1 rounded-full',
+          isProblem
+            ? 'text-destructive bg-destructive/10'
+            : 'text-primary bg-primary/10'
+        )}
+      >
+        {isProblem ? 'お悩み' : '解決策'}
+      </span>
+      <p className="font-bold text-base md:text-xl">{text}</p>
+      <Image src={icon} alt="" width={70} height={70} className="mt-auto" />
+    </div>
   );
 }

--- a/src/app/(landing)/components/problem-solution.tsx
+++ b/src/app/(landing)/components/problem-solution.tsx
@@ -46,7 +46,7 @@ export default function ProblemSolution() {
           ))}
         </div>
 
-        <div className="space-y-5">
+        <div>
           <div className="flex justify-center text-primary">
             <Icons.ArrowBigDown className="w-20 h-20" />
           </div>

--- a/src/app/(landing)/components/problem-solution.tsx
+++ b/src/app/(landing)/components/problem-solution.tsx
@@ -3,127 +3,18 @@ import Container from '@/components/shared/contaienr';
 import { Icons } from '@/components/icon/icons';
 import Image from 'next/image';
 
-const items = [
-  {
-    problem: 'スタッフとうまくコミュニケーションがとれない',
-    solution:
-      '1 on 1ミーティングの際に話のきっかけが生まれコミュニケーションの質が向上します',
-    problemIcon: '/images/problem-icon1.png',
-    solutionIcon: '/images/solution-icon2.png',
-  },
-  {
-    problem: 'スタッフの成長が見えにくい',
-    solution:
-      'グラフで成長具合が可視化されるので、どこに伸びしろがあるのかが分かりやすい',
-    problemIcon: '/images/problem-icon2.png',
-    solutionIcon: '/images/solution-icon3.png',
-  },
-  {
-    problem: '評価ツールが紙で管理が大変',
-    solution: '評価履歴をすぐに確認できる',
-    problemIcon: '/images/problem-icon3.png',
-    solutionIcon: '/images/solution-icon1.png',
-  },
-];
-
-function ProblemsCard({
-  text,
-  index,
-  icon,
-}: {
-  text: string;
-  index: number;
-  icon: string;
-}) {
-  return (
-    <div className="relative p-10 border-3 border-destructive/40 bg-primary-foreground rounded-xl">
-      <span className="text-xs font-bold text-destructive bg-destructive/10 px-2 py-1 rounded-full">
-        お悩み
-      </span>
-      <div className="w-8 h-8 bg-primary rounded-full text-primary-foreground flex items-center justify-center mb-3 mt-5 lg:hidden">
-        {index + 1}
-      </div>
-      <p className="pr-16 font-bold">{text}</p>
-      <Image
-        src={icon}
-        alt=""
-        width={70}
-        height={70}
-        className="absolute bottom-[-15] right-[-15] lg:bottom-[-40] lg:right-[-40]"
-      />
-    </div>
-  );
-}
-
-function SolutionCard({
-  text,
-  index,
-  icon,
-}: {
-  text: string;
-  index: number;
-  icon: string;
-}) {
-  return (
-    <div className="relative p-10 border-3 border-primary bg-primary-foreground rounded-xl">
-      <span className="text-xs font-bold text-primary bg-primary/10 px-2 py-1 rounded-full">
-        解決策
-      </span>
-      <div className="w-8 h-8 bg-primary rounded-full text-primary-foreground flex items-center justify-center mb-3 mt-5 lg:hidden">
-        {index + 1}
-      </div>
-      <p className="pr-16 font-bold">{text}</p>
-      <Image
-        src={icon}
-        alt=""
-        width={90}
-        height={90}
-        className="absolute bottom-[-15] right-[-15] lg:bottom-[-40] lg:right-[-40]"
-      />
-    </div>
-  );
-}
-
 export default function ProblemSolution() {
   return (
     <section id="problem-solution" className="scroll-mt-24">
       <Container>
-        <SectionTitle>Growth Finderが解決するもの</SectionTitle>
-        <div className="space-y-10">
-          <p className="text-center">
-            こんな
-            <span className="text-2xl font-bold text-primary">お悩み</span>
-            ありませんか？
-          </p>
-
-          <div className="space-y-10">
-            <div className="grid grid-cols-1 lg:grid-cols-3 gap-10">
-              {items.map((item, index) => (
-                <ProblemsCard
-                  text={item.problem}
-                  key={item.problem}
-                  icon={item.problemIcon}
-                  index={index}
-                />
-              ))}
-            </div>
-
-            <div className="flex justify-center text-primary">
-              <Icons.ArrowBigDown className="w-20 h-20" />
-            </div>
-
-            <div className="grid grid-cols-1 lg:grid-cols-3 gap-10">
-              {items.map((item, index) => (
-                <SolutionCard
-                  text={item.solution}
-                  key={item.solution}
-                  icon={item.solutionIcon}
-                  index={index}
-                />
-              ))}
-            </div>
-          </div>
-        </div>
+        <SectionTitle>
+          こんな
+          <span className="text-2xl md:text-4xl font-bold text-primary">
+            お悩み
+          </span>
+          ありませんか？
+        </SectionTitle>
+        
       </Container>
     </section>
   );

--- a/src/app/(landing)/components/problem-solution.tsx
+++ b/src/app/(landing)/components/problem-solution.tsx
@@ -3,6 +3,7 @@ import Container from '@/components/shared/contaienr';
 import { Icons } from '@/components/icon/icons';
 import Image from 'next/image';
 import { cn } from '@/lib/utils';
+import FadeIn from './fade-in';
 
 const items = [
   {
@@ -29,44 +30,54 @@ export default function ProblemSolution() {
   return (
     <section id="problem-solution" className="scroll-mt-24">
       <Container className="space-y-20">
-        <SectionTitle>
-          こんな
-          <span className="font-bold text-primary">お悩み</span>
-          ありませんか？
-        </SectionTitle>
+        <FadeIn delay={0}>
+          <SectionTitle>
+            こんな
+            <span className="font-bold text-primary">お悩み</span>
+            ありませんか？
+          </SectionTitle>
+        </FadeIn>
 
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-          {items.map((item) => (
-            <Card
-              text={item.problem}
-              key={item.problem}
-              icon={item.problemIcon}
-              variant="problem"
-            />
-          ))}
-        </div>
-
-        <div>
-          <div className="flex justify-center text-primary">
-            <Icons.ArrowBigDown className="w-20 h-20" />
+        <FadeIn delay={0}>
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+            {items.map((item, i) => (
+              <FadeIn key={item.problem} delay={i * 0.1}>
+                <Card
+                  text={item.problem}
+                  icon={item.problemIcon}
+                  variant="problem"
+                />
+              </FadeIn>
+            ))}
           </div>
+        </FadeIn>
 
-          <div className="text-2xl md:text-4xl font-bold text-center">
-            <span className="font-bold text-primary">Growth Finder</span>
-            が解決します
+        <FadeIn delay={0}>
+          <div>
+            <div className="flex justify-center text-primary">
+              <Icons.ArrowBigDown className="w-20 h-20" />
+            </div>
+
+            <div className="text-2xl md:text-4xl font-bold text-center">
+              <span className="font-bold text-primary">Growth Finder</span>
+              が解決します
+            </div>
           </div>
-        </div>
+        </FadeIn>
 
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-          {items.map((item) => (
-            <Card
-              text={item.solution}
-              key={item.solution}
-              icon={item.solutionIcon}
-              variant="solution"
-            />
-          ))}
-        </div>
+        <FadeIn delay={0}>
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+            {items.map((item, i) => (
+              <FadeIn key={item.solution} delay={i * 0.1}>
+                <Card
+                  text={item.solution}
+                  icon={item.solutionIcon}
+                  variant="solution"
+                />
+              </FadeIn>
+            ))}
+          </div>
+        </FadeIn>
       </Container>
     </section>
   );

--- a/src/app/(landing)/components/real-screen.tsx
+++ b/src/app/(landing)/components/real-screen.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 
 import SectionTitle from './section-title';
 import Container from '@/components/shared/contaienr';
+import { Icons } from '@/components/icon/icons';
 
 const screenshots = [
   {
@@ -72,20 +73,22 @@ export default function RealScreen() {
           </div>
         </div>
 
-        <div className="flex justify-center gap-4 mt-6">
+        <div className="flex justify-center gap-10 mt-6">
           <button
             onClick={handlePrev}
             disabled={currentIndex === 0}
-            className="px-4 py-2 border rounded-lg disabled:opacity-40 disabled:cursor-not-allowed"
+            aria-label="前のスライドへ"
+            className="hover:opacity-70 disabled:opacity-40 disabled:cursor-not-allowed"
           >
-            前へ
+            <Icons.ChevronLeft className="w-10 h-10" />
           </button>
           <button
             onClick={handleNext}
             disabled={currentIndex === screenshots.length - 1}
-            className="px-4 py-2 border rounded-lg disabled:opacity-40 disabled:cursor-not-allowed"
+            aria-label="次のスライドへ"
+            className="hover:opacity-70 disabled:opacity-40 disabled:cursor-not-allowed"
           >
-            次へ
+            <Icons.ChevronRight className="w-10 h-10" />
           </button>
         </div>
       </Container>

--- a/src/app/(landing)/components/real-screen.tsx
+++ b/src/app/(landing)/components/real-screen.tsx
@@ -52,15 +52,14 @@ export default function RealScreen() {
     <section>
       <Container>
         <SectionTitle>実際の画面</SectionTitle>
-
-        <div className="max-w-4xl mx-auto bg-card rounded-3xl border p-6">
-          <div className="overflow-hidden">
+        <div className="max-w-5xl mx-auto bg-card rounded-3xl border p-3 sm:p-4 md:p-5 lg:p-6">
+          <div className="relative overflow-hidden">
             <div
               className="flex transition-transform duration-500 ease-out"
               style={{ transform: `translateX(-${currentIndex * 100}%)` }}
             >
               {screenshots.map((screenshot) => (
-                <div key={screenshot.alt} className="w-full shrink-0 px-2">
+                <div key={screenshot.alt} className="relative w-full shrink-0">
                   <Image
                     src={screenshot.src}
                     alt={screenshot.alt}
@@ -68,32 +67,29 @@ export default function RealScreen() {
                     height={600}
                     className="w-full h-auto rounded-lg border"
                   />
-                  <p className="mt-4 text-center font-bold">
-                    {screenshot.title}
-                  </p>
                 </div>
               ))}
             </div>
-          </div>
-
-          <div className="flex justify-center gap-10 mt-6">
             <button
               onClick={handlePrev}
               disabled={currentIndex === 0}
               aria-label="前のスライドへ"
-              className="hover:opacity-70 disabled:opacity-40 disabled:cursor-not-allowed"
+              className="bg-white/80 rounded-full absolute left-3 lg:left-9 top-1/2 -translate-y-1/2 hover:opacity-70 disabled:opacity-40 disabled:cursor-not-allowed"
             >
-              <Icons.ChevronLeft className="w-10 h-10" />
+              <Icons.ChevronLeft className="w-7 sm:w-8 md:w-10 lg:w-15 h-7 sm:h-8 md:h-10 lg:h-15" />
             </button>
             <button
               onClick={handleNext}
               disabled={currentIndex === screenshots.length - 1}
               aria-label="次のスライドへ"
-              className="hover:opacity-70 disabled:opacity-40 disabled:cursor-not-allowed"
+              className="bg-white/80 rounded-full absolute right-3 lg:right-9 top-1/2 -translate-y-1/2 hover:opacity-70 disabled:opacity-40 disabled:cursor-not-allowed"
             >
-              <Icons.ChevronRight className="w-10 h-10" />
+              <Icons.ChevronRight className="w-7 sm:w-8 md:w-10 lg:w-15 h-7 sm:h-8 md:h-10 lg:h-15" />
             </button>
           </div>
+          <p className="text-center mt-4 font-bold text-xs sm:text-sm md:text-base lg:text-lg">
+            {screenshots[currentIndex].title}
+          </p>
         </div>
       </Container>
     </section>

--- a/src/app/(landing)/components/real-screen.tsx
+++ b/src/app/(landing)/components/real-screen.tsx
@@ -1,3 +1,6 @@
+'use client';
+
+import { useState } from 'react';
 import Image from 'next/image';
 
 import SectionTitle from './section-title';
@@ -34,62 +37,58 @@ const screenshots = [
   },
 ];
 
-type ScreenshotProps = {
-  src: string;
-  alt: string;
-  index: number;
-  title: string;
-  description: string;
-  priority?: boolean;
-};
-
 export default function RealScreen() {
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  const handleNext = () => {
+    setCurrentIndex(currentIndex + 1);
+  };
+  const handlePrev = () => {
+    setCurrentIndex(currentIndex - 1);
+  };
+
   return (
     <section>
       <Container>
         <SectionTitle>実際の画面</SectionTitle>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-          {screenshots.map((screenshot, index) => (
-            <Screenshot
-              key={screenshot.alt}
-              {...screenshot}
-              priority={index === 0}
-              index={index + 1}
-            />
-          ))}
+
+        <div className="overflow-hidden">
+          <div
+            className="flex transition-transform duration-500 ease-out"
+            style={{ transform: `translateX(-${currentIndex * 100}%)` }}
+          >
+            {screenshots.map((screenshot) => (
+              <div key={screenshot.alt} className="w-full shrink-0 px-2">
+                <Image
+                  src={screenshot.src}
+                  alt={screenshot.alt}
+                  width={1000}
+                  height={600}
+                  className="w-full h-auto rounded-lg border"
+                />
+                <p className="mt-4 text-center font-bold">{screenshot.title}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex justify-center gap-4 mt-6">
+          <button
+            onClick={handlePrev}
+            disabled={currentIndex === 0}
+            className="px-4 py-2 border rounded-lg disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            前へ
+          </button>
+          <button
+            onClick={handleNext}
+            disabled={currentIndex === screenshots.length - 1}
+            className="px-4 py-2 border rounded-lg disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            次へ
+          </button>
         </div>
       </Container>
     </section>
-  );
-}
-
-function Screenshot({
-  src,
-  alt,
-  index,
-  title,
-  description,
-  priority,
-}: ScreenshotProps) {
-  return (
-    <div className="bg-card rounded-3xl overflow-hidden border p-8 space-y-5">
-      <div className="flex items-center gap-3 font-bold">
-        <div className="flex items-center justify-center w-6 sm:w-8 h-6 sm:h-8 bg-primary rounded-full text-primary-foreground text-xs sm:text-sm md:text-base">
-          <span>{index}</span>
-        </div>
-        <h3 className="font-bold">{title}</h3>
-      </div>
-      <Image
-        src={src}
-        alt={alt}
-        priority={priority}
-        width={1000}
-        height={600}
-        className="w-full h-auto rounded-lg border"
-      />
-      <p className="text-xs md:text-sm lg:text-base text-muted-foreground">
-        {description}
-      </p>
-    </div>
   );
 }

--- a/src/app/(landing)/components/real-screen.tsx
+++ b/src/app/(landing)/components/real-screen.tsx
@@ -12,29 +12,21 @@ const screenshots = [
     src: '/images/growth-finder-screenshot1.png',
     alt: 'Growth Finderのコメント入力画像',
     title: 'ひとことコメント機能',
-    description:
-      '評価だけでは伝わらない成長や気づきを記録。「なぜその評価になったのか」を残せるため、1on1や面談時の振り返りがスムーズになります',
   },
   {
     src: '/images/growth-finder-screenshot2.png',
     alt: 'Growth Finderの評価入力画面',
     title: '評価入力機能',
-    description:
-      '誰が評価しても同じ基準でスタッフの習得状況を4段階で記録。評価基準を統一することで担当者ごとのばらつきを防ぎ、公平な評価と育成を実現します。',
   },
   {
     src: '/images/growth-finder-screenshot3.png',
     alt: 'Growth Finderのスタッフ評価画面',
     title: 'スタッフ評価画面',
-    description:
-      '入力した評価を自動で集計し、達成率やスキルバランスをグラフで可視化。スタッフ一人ひとりの強みや課題を把握し、次に育成すべきポイントが明確になります。',
   },
   {
     src: '/images/growth-finder-screenshot4.png',
     alt: 'Growth Finderのスタッフ一覧画面',
     title: 'スタッフ一覧画面',
-    description:
-      '登録されたスタッフの評価状況や達成度を一覧で確認。誰が未評価なのか、誰が成長しているのかをすぐに把握できます。',
   },
 ];
 

--- a/src/app/(landing)/components/real-screen.tsx
+++ b/src/app/(landing)/components/real-screen.tsx
@@ -8,62 +8,40 @@ const screenshots = [
     src: '/images/growth-finder-screenshot1.png',
     alt: 'Growth Finderのコメント入力画像',
     title: 'ひとことコメント機能',
-    description: '評価するときに思ったことを瞬時に記録することができます',
+    description:
+      '評価だけでは伝わらない成長や気づきを記録。「なぜその評価になったのか」を残せるため、1on1や面談時の振り返りがスムーズになります',
   },
   {
     src: '/images/growth-finder-screenshot2.png',
     alt: 'Growth Finderの評価入力画面',
-    title: '評価入力画面',
-    description: 'スムーズにスコアを入力できるようにシンプルな画面',
+    title: '評価入力機能',
+    description:
+      '誰が評価しても同じ基準でスタッフの習得状況を4段階で記録。評価基準を統一することで担当者ごとのばらつきを防ぎ、公平な評価と育成を実現します。',
   },
   {
     src: '/images/growth-finder-screenshot3.png',
     alt: 'Growth Finderのスタッフ評価画面',
     title: 'スタッフ評価画面',
-    description: 'グラフを使って成長を可視化',
+    description:
+      '入力した評価を自動で集計し、達成率やスキルバランスをグラフで可視化。スタッフ一人ひとりの強みや課題を把握し、次に育成すべきポイントが明確になります。',
   },
   {
     src: '/images/growth-finder-screenshot4.png',
     alt: 'Growth Finderのスタッフ一覧画面',
     title: 'スタッフ一覧画面',
-    description: 'スタッフの情報がまとまって見やすい',
+    description:
+      '登録されたスタッフの評価状況や達成度を一覧で確認。誰が未評価なのか、誰が成長しているのかをすぐに把握できます。',
   },
 ];
 
 type ScreenshotProps = {
   src: string;
   alt: string;
+  index: number;
   title: string;
   description: string;
   priority?: boolean;
 };
-
-function Screenshot({
-  src,
-  alt,
-  title,
-  description,
-  priority,
-}: ScreenshotProps) {
-  return (
-    <div className="bg-card rounded-3xl overflow-hidden border">
-      <div className="p-6 lg:p-10">
-        <Image
-          src={src}
-          alt={alt}
-          priority={priority}
-          width={1000}
-          height={600}
-          className="w-full h-auto rounded-lg border"
-        />
-      </div>
-      <div className="border-t p-7 lg:p-12 space-y-1">
-        <h3 className="font-bold text-primary">{title}</h3>
-        <p className="text-sm text-muted-foreground">{description}</p>
-      </div>
-    </div>
-  );
-}
 
 export default function RealScreen() {
   return (
@@ -76,10 +54,46 @@ export default function RealScreen() {
               key={screenshot.alt}
               {...screenshot}
               priority={index === 0}
+              index={index + 1}
             />
           ))}
         </div>
       </Container>
     </section>
+  );
+}
+
+function Screenshot({
+  src,
+  alt,
+  index,
+  title,
+  description,
+  priority,
+}: ScreenshotProps) {
+  return (
+    <div className="bg-card rounded-3xl overflow-hidden border">
+      <div className="p-6 lg:p-10">
+        <div className="flex items-center gap-3 font-bold mb-5">
+          <div className="flex items-center justify-center w-6 sm:w-8 h-6 sm:h-8 bg-primary rounded-full text-primary-foreground text-xs sm:text-sm md:text-base">
+            <span>{index}</span>
+          </div>
+          <h3 className="font-bold">{title}</h3>
+        </div>
+        <Image
+          src={src}
+          alt={alt}
+          priority={priority}
+          width={1000}
+          height={600}
+          className="w-full h-auto rounded-lg border"
+        />
+      </div>
+      <div className="border-t p-7 lg:p-12 space-y-1">
+        <p className="text-xs md:text-sm lg:text-base text-muted-foreground">
+          {description}
+        </p>
+      </div>
+    </div>
   );
 }

--- a/src/app/(landing)/components/real-screen.tsx
+++ b/src/app/(landing)/components/real-screen.tsx
@@ -53,43 +53,47 @@ export default function RealScreen() {
       <Container>
         <SectionTitle>実際の画面</SectionTitle>
 
-        <div className="overflow-hidden">
-          <div
-            className="flex transition-transform duration-500 ease-out"
-            style={{ transform: `translateX(-${currentIndex * 100}%)` }}
-          >
-            {screenshots.map((screenshot) => (
-              <div key={screenshot.alt} className="w-full shrink-0 px-2">
-                <Image
-                  src={screenshot.src}
-                  alt={screenshot.alt}
-                  width={1000}
-                  height={600}
-                  className="w-full h-auto rounded-lg border"
-                />
-                <p className="mt-4 text-center font-bold">{screenshot.title}</p>
-              </div>
-            ))}
+        <div className="max-w-4xl mx-auto bg-card rounded-3xl border p-6">
+          <div className="overflow-hidden">
+            <div
+              className="flex transition-transform duration-500 ease-out"
+              style={{ transform: `translateX(-${currentIndex * 100}%)` }}
+            >
+              {screenshots.map((screenshot) => (
+                <div key={screenshot.alt} className="w-full shrink-0 px-2">
+                  <Image
+                    src={screenshot.src}
+                    alt={screenshot.alt}
+                    width={1000}
+                    height={600}
+                    className="w-full h-auto rounded-lg border"
+                  />
+                  <p className="mt-4 text-center font-bold">
+                    {screenshot.title}
+                  </p>
+                </div>
+              ))}
+            </div>
           </div>
-        </div>
 
-        <div className="flex justify-center gap-10 mt-6">
-          <button
-            onClick={handlePrev}
-            disabled={currentIndex === 0}
-            aria-label="前のスライドへ"
-            className="hover:opacity-70 disabled:opacity-40 disabled:cursor-not-allowed"
-          >
-            <Icons.ChevronLeft className="w-10 h-10" />
-          </button>
-          <button
-            onClick={handleNext}
-            disabled={currentIndex === screenshots.length - 1}
-            aria-label="次のスライドへ"
-            className="hover:opacity-70 disabled:opacity-40 disabled:cursor-not-allowed"
-          >
-            <Icons.ChevronRight className="w-10 h-10" />
-          </button>
+          <div className="flex justify-center gap-10 mt-6">
+            <button
+              onClick={handlePrev}
+              disabled={currentIndex === 0}
+              aria-label="前のスライドへ"
+              className="hover:opacity-70 disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              <Icons.ChevronLeft className="w-10 h-10" />
+            </button>
+            <button
+              onClick={handleNext}
+              disabled={currentIndex === screenshots.length - 1}
+              aria-label="次のスライドへ"
+              className="hover:opacity-70 disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              <Icons.ChevronRight className="w-10 h-10" />
+            </button>
+          </div>
         </div>
       </Container>
     </section>

--- a/src/app/(landing)/components/real-screen.tsx
+++ b/src/app/(landing)/components/real-screen.tsx
@@ -50,7 +50,7 @@ export default function RealScreen() {
 
   return (
     <section>
-      <Container>
+      <Container className="space-y-20">
         <SectionTitle>実際の画面</SectionTitle>
         <div className="max-w-5xl mx-auto bg-card rounded-3xl border p-3 sm:p-4 md:p-5 lg:p-6">
           <div className="relative overflow-hidden">

--- a/src/app/(landing)/components/real-screen.tsx
+++ b/src/app/(landing)/components/real-screen.tsx
@@ -72,28 +72,24 @@ function Screenshot({
   priority,
 }: ScreenshotProps) {
   return (
-    <div className="bg-card rounded-3xl overflow-hidden border">
-      <div className="p-6 lg:p-10">
-        <div className="flex items-center gap-3 font-bold mb-5">
-          <div className="flex items-center justify-center w-6 sm:w-8 h-6 sm:h-8 bg-primary rounded-full text-primary-foreground text-xs sm:text-sm md:text-base">
-            <span>{index}</span>
-          </div>
-          <h3 className="font-bold">{title}</h3>
+    <div className="bg-card rounded-3xl overflow-hidden border p-8 space-y-5">
+      <div className="flex items-center gap-3 font-bold">
+        <div className="flex items-center justify-center w-6 sm:w-8 h-6 sm:h-8 bg-primary rounded-full text-primary-foreground text-xs sm:text-sm md:text-base">
+          <span>{index}</span>
         </div>
-        <Image
-          src={src}
-          alt={alt}
-          priority={priority}
-          width={1000}
-          height={600}
-          className="w-full h-auto rounded-lg border"
-        />
+        <h3 className="font-bold">{title}</h3>
       </div>
-      <div className="border-t p-7 lg:p-12 space-y-1">
-        <p className="text-xs md:text-sm lg:text-base text-muted-foreground">
-          {description}
-        </p>
-      </div>
+      <Image
+        src={src}
+        alt={alt}
+        priority={priority}
+        width={1000}
+        height={600}
+        className="w-full h-auto rounded-lg border"
+      />
+      <p className="text-xs md:text-sm lg:text-base text-muted-foreground">
+        {description}
+      </p>
     </div>
   );
 }

--- a/src/app/(landing)/components/section-title.tsx
+++ b/src/app/(landing)/components/section-title.tsx
@@ -10,12 +10,7 @@ export default function SectionTitle({
   className = '',
 }: SectionTitleProps) {
   return (
-    <h2
-      className={cn(
-        'text-2xl md:text-4xl mb-12 text-center font-bold',
-        className
-      )}
-    >
+    <h2 className={cn('text-2xl md:text-4xl text-center font-bold', className)}>
       {children}
     </h2>
   );

--- a/src/app/(landing)/components/usage.tsx
+++ b/src/app/(landing)/components/usage.tsx
@@ -41,7 +41,7 @@ type UsageItemProps = {
 export default function Usage() {
   return (
     <section id="usage">
-      <Container>
+      <Container className="space-y-20">
         <SectionTitle>Growth Finderの使い方</SectionTitle>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
           {usageList.map((item) => (

--- a/src/app/(landing)/components/usage.tsx
+++ b/src/app/(landing)/components/usage.tsx
@@ -1,7 +1,5 @@
-import Link from 'next/link';
 import { LucideIcon } from 'lucide-react';
 
-import { Button } from '../../../components/ui/button';
 import { Icons } from '../../../components/icon/icons';
 import SectionTitle from './section-title';
 import Container from '@/components/shared/contaienr';
@@ -11,11 +9,7 @@ const usageList = [
     index: '1',
     icon: Icons.Edit3,
     title: 'アカウント',
-    description: (
-      <Button size="sm" asChild variant="ghost">
-        <Link href="/signup">すぐに始める</Link>
-      </Button>
-    ),
+    description: '1分でアカウント作成',
   },
   {
     index: '2',
@@ -44,19 +38,6 @@ type UsageItemProps = {
   description: React.ReactNode;
 };
 
-function UsageItem({ index, icon: Icon, title, description }: UsageItemProps) {
-  return (
-    <div className="bg-primary-foreground w-full p-6 lg:p-12 border rounded-2xl">
-      <p className="text-xl md:text-2xl">{index}</p>
-      <div className="text-center mt-3">
-        <Icon className="w-8 md:w-10 h-8 md:h-10 mx-auto text-primary" />
-        <p className="mt-3 text-base font-semibold">{title}</p>
-        <div className="mt-4 text-xs text-muted-foreground">{description}</div>
-      </div>
-    </div>
-  );
-}
-
 export default function Usage() {
   return (
     <section id="usage">
@@ -69,5 +50,20 @@ export default function Usage() {
         </div>
       </Container>
     </section>
+  );
+}
+
+function UsageItem({ index, icon: Icon, title, description }: UsageItemProps) {
+  return (
+    <div className="bg-primary-foreground w-full p-8 border rounded-2xl">
+      <div className="flex items-center justify-center font-bold w-6 sm:w-8 h-6 sm:h-8 bg-primary rounded-full text-primary-foreground text-sm sm:text-base">
+        <span>{index}</span>
+      </div>
+      <div className="text-center space-y-3">
+        <Icon className="w-12 md:w-14 h-12 md:h-14 mx-auto text-primary" />
+        <p className="text-lg font-semibold">{title}</p>
+        <div className="text-sm text-primary font-bold">{description}</div>
+      </div>
+    </div>
   );
 }

--- a/src/app/(landing)/components/usage.tsx
+++ b/src/app/(landing)/components/usage.tsx
@@ -3,6 +3,7 @@ import { LucideIcon } from 'lucide-react';
 import { Icons } from '../../../components/icon/icons';
 import SectionTitle from './section-title';
 import Container from '@/components/shared/contaienr';
+import FadeIn from './fade-in';
 
 const usageList = [
   {
@@ -42,10 +43,14 @@ export default function Usage() {
   return (
     <section id="usage">
       <Container className="space-y-20">
-        <SectionTitle>Growth Finderの使い方</SectionTitle>
+        <FadeIn delay={0}>
+          <SectionTitle>Growth Finderの使い方</SectionTitle>
+        </FadeIn>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
-          {usageList.map((item) => (
-            <UsageItem key={item.title} {...item} />
+          {usageList.map((item, i) => (
+            <FadeIn key={item.title} delay={i * 0.1}>
+              <UsageItem {...item} />
+            </FadeIn>
           ))}
         </div>
       </Container>

--- a/src/app/(landing)/page.tsx
+++ b/src/app/(landing)/page.tsx
@@ -17,9 +17,7 @@ export default function LandingPage() {
         <RealScreen />
       </FadeIn>
 
-      <FadeIn delay={0}>
-        <Usage />
-      </FadeIn>
+      <Usage />
 
       <FadeIn delay={0}>
         <CallToAction />

--- a/src/app/(landing)/page.tsx
+++ b/src/app/(landing)/page.tsx
@@ -4,15 +4,26 @@ import Footer from './components/footer';
 import Hero from './components/hero';
 import RealScreen from './components/real-screen';
 import Usage from './components/usage';
+import FadeIn from './components/fade-in';
 
 export default function LandingPage() {
   return (
     <div className="space-y-24 md:space-y-32 lg:space-y-40">
       <Hero />
+
       <ProblemSolution />
-      <RealScreen />
-      <Usage />
-      <CallToAction />
+
+      <FadeIn delay={0}>
+        <RealScreen />
+      </FadeIn>
+
+      <FadeIn delay={0}>
+        <Usage />
+      </FadeIn>
+
+      <FadeIn delay={0}>
+        <CallToAction />
+      </FadeIn>
       <Footer />
     </div>
   );

--- a/src/app/(landing)/page.tsx
+++ b/src/app/(landing)/page.tsx
@@ -7,7 +7,7 @@ import Usage from './components/usage';
 
 export default function LandingPage() {
   return (
-    <div className="space-y-40">
+    <div className="space-y-24 md:space-y-32 lg:space-y-40">
       <Hero />
       <ProblemSolution />
       <RealScreen />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -126,6 +126,21 @@
   }
 }
 
+@keyframes bounce-gentle {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+
+  50% {
+    transform: translateY(8px);
+  }
+}
+
+.animate-bounce-gentle {
+  animation: bounce-gentle 2s ease-in-out infinite;
+}
+
 button {
   cursor: pointer;
 }

--- a/src/components/icon/icons.tsx
+++ b/src/components/icon/icons.tsx
@@ -45,6 +45,7 @@ import {
 } from 'lucide-react';
 
 import { FaXTwitter, FaGithub } from 'react-icons/fa6';
+import { TbArrowBigDownLinesFilled } from 'react-icons/tb';
 import {
   FaRunning,
   FaRegCommentDots,
@@ -99,7 +100,7 @@ export const Icons = {
   ArrowBigDown,
   MessageSquareText,
   ChartColumnIncreasing,
-  
+
   FaXTwitter,
   FaGithub,
   FcGoogle,
@@ -109,4 +110,5 @@ export const Icons = {
   FaHammer,
   FaHandHoldingHeart,
   MdCleaningServices,
+  TbArrowBigDownLinesFilled,
 };

--- a/src/components/icon/icons.tsx
+++ b/src/components/icon/icons.tsx
@@ -40,6 +40,8 @@ import {
   MousePointer,
   TriangleAlert,
   ArrowBigDown,
+  MessageSquareText,
+  ChartColumnIncreasing,
 } from 'lucide-react';
 
 import { FaXTwitter, FaGithub } from 'react-icons/fa6';
@@ -95,6 +97,9 @@ export const Icons = {
   MousePointer,
   TriangleAlert,
   ArrowBigDown,
+  MessageSquareText,
+  ChartColumnIncreasing,
+  
   FaXTwitter,
   FaGithub,
   FcGoogle,


### PR DESCRIPTION
## 概要
LPをよりリッチにするため、スクロールアニメーションの追加とレイアウト・余白のブラッシュアップを行う。

## 対応
- スクロール連動のFadeInコンポーネント作成

## やること
- [x] FadeInコンポーネント（IntersectionObserver + animate-in）の実装
- [x] Heroセクションのレイアウト改善（左寄せ化、デバイスモック差し替え、特徴アイコン追加）
- [x] Heroのコピー見直し（ベネフィット型の見出しへ）
- [x] 解決策セクションのレイアウト改善
- [x] 実際の画面セクションレイアウト改善
- [x] 使い方セクションレイアウト改善
- [x] Call to action セクションレイアウト改善
- [x] 実際の画面セクションの画像をカルーセルで表示
- [x] 全体の余白リズム調整（space-y-40の見直し）
- [x] 各セクションへのFadeIn適用
- [x] ProblemSolution / RealScreen / Usage のレイアウト微調整

## 設計判断

### アニメーションをtransitionではなく、animation(@keyframes)を使用した理由
登場系のアニメーション（スクロールで要素を表示する等）には、
transitionではなくanimation（@keyframes）を採用した。
transitionは「状態の変化を補間する」仕組みで、変化前の状態
（opacity-0）で一度描画されていることが前提となる。登場系では
初期状態が描画される前に表示状態へ切り替わると補間が発生しない
ケースがあり、描画タイミングに左右されうる。
一方 animation は「クラスが付与された瞬間に再生する」仕組みで、
変化前の描画を前提としないため、登場アニメーションでは安定して
発火する。また tw-animate-css を既に導入済みのため、その animate-in
を使うことで新たなライブラリを追加せず実現できる点も選定理由。
prefers-reduced-motion にも対応している。