### PR TITLE
feat: デモログイン用ボタンにローディングアイコンを実装

### DIFF
--- a/src/app/(landing)/components/demo-login-button.tsx
+++ b/src/app/(landing)/components/demo-login-button.tsx
@@ -1,5 +1,4 @@
 import { loginAsDemo } from '@/app/_actions/demo-login';
-import { cn } from '@/lib/utils';
 import DemoLoginSubmitButton from './demo-login-submit-button';
 
 export default function DemoLoginButton({ className }: { className?: string }) {

--- a/src/app/(landing)/components/demo-login-button.tsx
+++ b/src/app/(landing)/components/demo-login-button.tsx
@@ -1,16 +1,11 @@
 import { loginAsDemo } from '@/app/_actions/demo-login';
-import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
+import DemoLoginSubmitButton from './demo-login-submit-button';
 
 export default function DemoLoginButton({ className }: { className?: string }) {
   return (
     <form action={loginAsDemo}>
-      <Button
-        type="submit"
-        className={cn('w-50 md:w-96 rounded-4xl', className)}
-      >
-        デモを試す
-      </Button>
+      <DemoLoginSubmitButton className={className} />
     </form>
   );
 }

--- a/src/app/(landing)/components/demo-login-submit-button.tsx
+++ b/src/app/(landing)/components/demo-login-submit-button.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useFormStatus } from 'react-dom';
+import { Button } from '@/components/ui/button';
+import LoaderCircleIcon from '@/components/shared/loader-circle';
+import { cn } from '@/lib/utils';
+
+export default function DemoLoginSubmitButton({
+  className,
+}: {
+  className?: string;
+}) {
+  const { pending } = useFormStatus();
+  return (
+    <Button
+      type="submit"
+      disabled={pending}
+      className={cn('w-50 md:w-96 rounded-4xl', className)}
+    >
+      {pending ? <LoaderCircleIcon /> : 'デモを試す'}
+    </Button>
+  );
+}


### PR DESCRIPTION
## 概要
デモルート用のログインボタンにローディングアイコンが無かった。
ボタンを押下しても通信中の状態が分からないので実装する。

## 対応
- LoginSubmitButtonコンポーネントを作成

## 設計理由
**useStateではなくuseFormStatusを使った理由**

useFormStatusはReact DOMの組み込みフックで、
親の<form>のsubmit状態をコンテキスト経由で取得できる。

useStateを使う場合は親コンポーネントで状態管理するので、
ハンドラーを作成してformのactionに渡す手間がかかる。
useFormStatusはformのactonにそのまま関数を渡すことができ、ボタン側だけでpendingが取得できるためこちらを採用した。

**ボタンのみをクライアントコンポーネントに分離した理由**

DemoLoginButton全体をuse clientにすると
Server ActionであるloginAsDemoもクライアントバンドルに含まれてしまう。
ボタン部分のみをDemoLoginSubmitButtonとして切り出すことで
Server Actionをサーバー側に留めつつ、UIの状態管理だけをクライアントで行う構成にした。