### PR TITLE
fix: 下書き保存した評価が進捗率に完了としてカウントされる問題を修正 (#176)

### DIFF
--- a/src/app/(protected)/admin/page.tsx
+++ b/src/app/(protected)/admin/page.tsx
@@ -46,6 +46,7 @@ export default async function AdminPage() {
           `
     id,
     staff_id,
+    status,
       evaluation_sections (
       id,
       section_type,
@@ -75,10 +76,11 @@ export default async function AdminPage() {
   );
 
   const totalStaffs = staffs.length;
-  const evaluatedStaffs = totalEvaluations?.length ?? 0;
+  const evaluatedStaffs =
+    totalEvaluations?.filter((e) => e.status === 'completed').length ?? 0;
+  const unevaluatedStaffs = totalStaffs - evaluatedStaffs;
   const progressRate =
     totalStaffs > 0 ? Math.round((evaluatedStaffs / totalStaffs) * 100) : 0;
-  const unevaluatedStaffs = totalStaffs - evaluatedStaffs;
   const unevaluatedStaffLists = staffs.filter(
     (staff) =>
       !totalEvaluations?.some((evaluation) => evaluation.staff_id === staff.id)

--- a/types/evaluations.ts
+++ b/types/evaluations.ts
@@ -95,7 +95,6 @@ export type TotalEvaluations = Pick<
   'id' | 'staff_id'
 > & {
   status: Status;
-} & {
   evaluation_sections: (Pick<
     Tables<'evaluation_sections'>,
     | 'id'

--- a/types/evaluations.ts
+++ b/types/evaluations.ts
@@ -12,6 +12,8 @@ export type TabType = SectionType | 'all';
 
 export type Category = 'skill' | 'hospitality' | 'cleanliness';
 
+export type Status = 'completed' | 'draft';
+
 export type FormattedEvaluation = Record<SectionType, SectionData>;
 
 export type EvaluationItem = Pick<
@@ -92,6 +94,8 @@ export type TotalEvaluations = Pick<
   Tables<'evaluations'>,
   'id' | 'staff_id'
 > & {
+  status: Status;
+} & {
   evaluation_sections: (Pick<
     Tables<'evaluation_sections'>,
     | 'id'


### PR DESCRIPTION
## 概要
下書き状態の評価が、完了として扱われてしまう問題への対応。

## 原因
evaluations レコードの有無だけで「評価済み」を判定していたため、status='draft'（下書き）の評価も完了とみなされ、進捗率が実態より高く表示されていた。本来は status='completed' のみを完了として扱う。

## 対応内容
- [x] 進捗率の算出を`status='completed'`ベースに修正
- [x] unevaluatedStaffListsの集計対象を整理

Closes #176