### PR TITLE
Fix/local auth grant

### DIFF
--- a/supabase/migrations/20260624053110_grant_dml_privileges.sql
+++ b/supabase/migrations/20260624053110_grant_dml_privileges.sql
@@ -1,0 +1,7 @@
+-- 全テーブルでRLSが有効であることを確認済み。
+-- RLSが行レベルでアクセスを制御するため、テーブルレベルのGRANTを付与する。
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO authenticated;
+
+-- 今後追加されるテーブルにも自動付与（再発防止）
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO authenticated;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -261,6 +261,25 @@ INSERT INTO evaluations (
   'キャッシャーでは自らお客様へ商品を進めることができる。バリスタでは忙しい時間帯でもカフェラテをきれいに作成できるようになっている。後輩を指導できている。'
 );
 
+INSERT INTO auth.identities (
+  provider_id,
+  user_id,
+  identity_data,
+  provider,
+  last_sign_in_at,
+  created_at,
+  updated_at
+)
+SELECT
+  id,
+  id,
+  jsonb_build_object('sub', id::text, 'email', email),
+  'email',
+  NOW(),
+  NOW(),
+  NOW()
+FROM auth.users;
+
 INSERT INTO evaluations (
   id,
   organization_id,


### PR DESCRIPTION
## 概要
Supabaseのバージョン更新に伴い、ローカル環境でログインできなくなった問題を修正する。

Closes #179

## 背景
Supabaseの仕様変更（2025-05-30以降、テーブルはデフォルトで非公開）により、
authenticatedロールにテーブルレベルのDML権限が無く、ログイン後のprofiles
取得が permission denied で失敗し、リダイレクトループに陥っていた。
あわせて、seedがauth.identitiesを作成しておらず、本番とローカルでユーザーの
生成方法に差異がある状態だった。

## 対応内容
- [x] authenticatedロールへのGRANTマイグレーションを追加（全テーブルRLS有効を確認のうえ付与）
- [x] ALTER DEFAULT PRIVILEGES で今後追加されるテーブルにも自動付与（再発防止）
- [x] anonには付与しない（未ログインはデータにアクセスさせない方針）
- [x] seedにauth.identitiesの作成を追加（本番に合わせる）

## 確認方法
1. `supabase db reset` を実行
2. デモログイン・通常ログイン・Google OAuthが通ることを確認
3. auth.identities が5件作成されていることを確認