### PR TITLE
Fix/182 staff list label

### DIFF
--- a/src/app/(protected)/admin/staff/components/staff-card.tsx
+++ b/src/app/(protected)/admin/staff/components/staff-card.tsx
@@ -61,27 +61,38 @@ export default function StaffCard({
           <p>役職 {staff.role}</p>
           <p>店舗名 {staff.store_name}</p>
         </div>
-        {staffEvaluation && evaluation ? (
+        {!evaluation && (
+          <div className="mt-3 pt-3 border-t space-y-2">
+            <p className="text-xs font-medium text-muted-foreground">
+              現在の評価
+            </p>
+            <span className="text-xs text-muted-foreground mt-1 bg-gray-400/10 rounded-xl p-2">
+              未完了
+            </span>
+          </div>
+        )}
+        {staffEvaluation?.status === 'completed' && evaluation && (
           <div className="mt-3 pt-3 border-t space-y-2">
             <p className="text-xs font-medium text-muted-foreground">
               現在の評価
             </p>
             <div className="flex flex-wrap gap-2">
-              <span className="text-xs text-muted-foreground mt-1 bg-primary/10 rounded-xl p-2">
+              <span className="text-xs text-muted-foreground mt-1 bg-green-400/10 rounded-xl p-2">
                 {`総合評価: ${evaluation.rank}`}
               </span>
-              <span className="text-xs text-muted-foreground mt-1 bg-primary/10 rounded-xl p-2">
+              <span className="text-xs text-muted-foreground mt-1 bg-green-400/10 rounded-xl p-2">
                 {`総合達成率: ${evaluation.rate}%`}
               </span>
             </div>
           </div>
-        ) : (
+        )}
+        {staffEvaluation?.status === 'draft' && (
           <div className="mt-3 pt-3 border-t space-y-2">
             <p className="text-xs font-medium text-muted-foreground">
               現在の評価
             </p>
-            <span className="text-xs text-muted-foreground mt-1 bg-red-100 rounded-xl p-2">
-              未評価
+            <span className="text-xs text-muted-foreground mt-1 bg-blue-400/10 rounded-xl p-2">
+              下書き
             </span>
           </div>
         )}

--- a/src/app/(protected)/admin/staff/components/staff-card.tsx
+++ b/src/app/(protected)/admin/staff/components/staff-card.tsx
@@ -23,10 +23,6 @@ export default function StaffCard({
   selectedPeriod,
   staffEvaluation,
 }: StaffCardProps) {
-  const evaluation = staffEvaluation
-    ? calcEvaluation(staffEvaluation.evaluation_sections)
-    : null;
-
   return (
     <Card className="relative">
       <CardContent className="pb-4">
@@ -61,42 +57,56 @@ export default function StaffCard({
           <p>役職 {staff.role}</p>
           <p>店舗名 {staff.store_name}</p>
         </div>
-        {!staffEvaluation && (
-          <div className="mt-3 pt-3 border-t space-y-2">
-            <p className="text-xs font-medium text-muted-foreground">
-              現在の評価
-            </p>
-            <span className="text-xs text-muted-foreground mt-1 bg-gray-400/10 rounded-xl p-2">
-              未完了
-            </span>
-          </div>
-        )}
-        {staffEvaluation?.status === 'completed' && evaluation && (
-          <div className="mt-3 pt-3 border-t space-y-2">
-            <p className="text-xs font-medium text-muted-foreground">
-              現在の評価
-            </p>
-            <div className="flex flex-wrap gap-2">
-              <span className="text-xs text-muted-foreground mt-1 bg-green-400/10 rounded-xl p-2">
-                {`総合評価: ${evaluation.rank}`}
-              </span>
-              <span className="text-xs text-muted-foreground mt-1 bg-green-400/10 rounded-xl p-2">
-                {`総合達成率: ${evaluation.rate}%`}
-              </span>
-            </div>
-          </div>
-        )}
-        {staffEvaluation?.status === 'draft' && (
-          <div className="mt-3 pt-3 border-t space-y-2">
-            <p className="text-xs font-medium text-muted-foreground">
-              現在の評価
-            </p>
-            <span className="text-xs text-muted-foreground mt-1 bg-blue-400/10 rounded-xl p-2">
-              下書き
-            </span>
-          </div>
-        )}
+        <EvaluationLabel staffEvaluation={staffEvaluation} />
       </CardContent>
     </Card>
+  );
+}
+
+function EvaluationLabel({
+  staffEvaluation,
+}: {
+  staffEvaluation: ExistingEvaluationForStaffCard | undefined;
+}) {
+  if (!staffEvaluation)
+    return (
+      <LabelWrapper>
+        <span className="text-xs text-muted-foreground mt-1 bg-gray-400/10 rounded-xl p-2">
+          未完了
+        </span>
+      </LabelWrapper>
+    );
+
+  if (staffEvaluation.status === 'draft')
+    return (
+      <LabelWrapper>
+        <span className="text-xs text-muted-foreground mt-1 bg-blue-400/10 rounded-xl p-2">
+          下書き
+        </span>
+      </LabelWrapper>
+    );
+
+  const evaluation = calcEvaluation(staffEvaluation.evaluation_sections);
+
+  return (
+    <LabelWrapper>
+      <div className="flex flex-wrap gap-2">
+        <span className="text-xs text-muted-foreground mt-1 bg-green-400/10 rounded-xl p-2">
+          {`総合評価: ${evaluation.rank}`}
+        </span>
+        <span className="text-xs text-muted-foreground mt-1 bg-green-400/10 rounded-xl p-2">
+          {`総合達成率: ${evaluation.rate}%`}
+        </span>
+      </div>
+    </LabelWrapper>
+  );
+}
+
+function LabelWrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mt-3 pt-3 border-t space-y-2">
+      <p className="text-xs font-medium text-muted-foreground">現在の評価</p>
+      {children}
+    </div>
   );
 }

--- a/src/app/(protected)/admin/staff/components/staff-card.tsx
+++ b/src/app/(protected)/admin/staff/components/staff-card.tsx
@@ -61,7 +61,7 @@ export default function StaffCard({
           <p>役職 {staff.role}</p>
           <p>店舗名 {staff.store_name}</p>
         </div>
-        {!evaluation && (
+        {!staffEvaluation && (
           <div className="mt-3 pt-3 border-t space-y-2">
             <p className="text-xs font-medium text-muted-foreground">
               現在の評価

--- a/src/app/(protected)/admin/staff/page.tsx
+++ b/src/app/(protected)/admin/staff/page.tsx
@@ -41,6 +41,7 @@ export default async function StaffManagementPage() {
           `
     id,
     staff_id,
+    status,
       evaluation_sections (
         section_type,
         skill_score,
@@ -53,8 +54,7 @@ export default async function StaffManagementPage() {
     `
         )
         .eq('organization_id', orgId)
-        .eq('evaluation_period_id', selectedPeriod.id)
-        .eq('status', 'completed')) as {
+        .eq('evaluation_period_id', selectedPeriod.id)) as {
         data: ExistingEvaluationForStaffCard[] | null;
         error: unknown;
       })

--- a/types/evaluations.ts
+++ b/types/evaluations.ts
@@ -47,6 +47,8 @@ export type ExistingEvaluationForStaffCard = Pick<
   Tables<'evaluations'>,
   'id' | 'staff_id'
 > & {
+  status: Status;
+} & {
   evaluation_sections: Pick<
     ExistingEvaluationSection,
     | 'section_type'


### PR DESCRIPTION
## 概要
スタッフ一覧の評価ラベルが、評価ステータス（status）を見ずに evaluations の
有無だけで出し分けていた問題を修正する。

Closes #182

## 背景
スタッフ一覧では、評価ラベルを evaluations レコードの有無のみで判定しており、
下書き(draft)状態のスタッフが「未評価」と表示されていた。
ダッシュボード（#176・#177）と同じく、status を参照していないことが原因。

## 対応内容
- [x] evaluations の取得クエリに status を追加（completed での絞り込みを削除）
- [x] status を基準に 未完了 / 下書き / 完了 の3軸でラベルを出し分け
- [x] 判定ロジックを EvaluationLabel に切り出し、早期returnで3状態を排他的に分岐
- [x] 完了時のみ calcEvaluation を実行し、評価結果の null 可能性を排除
- [x] 共通の枠を LabelWrapper にまとめ、重複を解消