### PR TITLE
Fix/185 detail status filter

### DIFF
--- a/src/app/(protected)/admin/staff/[staffId]/page.tsx
+++ b/src/app/(protected)/admin/staff/[staffId]/page.tsx
@@ -5,6 +5,7 @@ import { redirect } from 'next/navigation';
 import AdminContainer from '../../components/admin-contaimer';
 import { requireAdmin } from '@/lib/utils/requireAdmin';
 import {
+  ChartDataPoint,
   ExistingEvaluation,
   PeriodForChart,
 } from '../../../../../../types/evaluations';
@@ -14,6 +15,12 @@ import StaffEvaluationSection from '@/components/evaluation/staff-evaluation-sec
 
 type StaffDetailPageProps = {
   params: { staffId: string };
+};
+
+type StaffEvaluationProps = {
+  selectedPeriod?: { id: string; name: string } | null; //TODO: 型をどこで定義するのか？
+  targetEvaluation?: ExistingEvaluation | null;
+  chartData: ChartDataPoint[];
 };
 
 export default async function StaffDetailPage({
@@ -119,23 +126,68 @@ export default async function StaffDetailPage({
         targetStaff={targetStaff}
         staffId={staffId}
       />
-      {!selectedPeriod ? (
-        <p className="flex items-center gap-2 text-sm text-muted-foreground">
-          <Icons.CircleAlert />
-          評価期間が設定されていません
-        </p>
-      ) : !targetEvaluation ? (
-        <p className="flex items-center gap-2 text-sm text-muted-foreground">
-          <Icons.CircleAlert />
-          まだ評価が登録されていません
-        </p>
-      ) : (
-        <StaffEvaluationSection
-          selectedPeriod={selectedPeriod}
-          targetEvaluation={targetEvaluation}
-          chartData={chartData}
-        />
-      )}
+
+      <StaffEvaluation
+        selectedPeriod={selectedPeriod}
+        targetEvaluation={targetEvaluation}
+        chartData={chartData}
+      />
     </AdminContainer>
   );
 }
+
+function StaffEvaluation({
+  selectedPeriod,
+  targetEvaluation,
+  chartData,
+}: StaffEvaluationProps) {
+  if (!selectedPeriod)
+    return (
+      <p className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Icons.CircleAlert />
+        評価期間が設定されていません
+      </p>
+    );
+
+  if (!targetEvaluation)
+    return (
+      <p className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Icons.CircleAlert />
+        まだ評価が登録されていません
+      </p>
+    );
+
+  if (targetEvaluation.status === 'draft')
+    return (
+      <p className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Icons.CircleAlert />
+        下書き中のため表示できません
+      </p>
+    );
+
+  return (
+    <StaffEvaluationSection
+      selectedPeriod={selectedPeriod}
+      targetEvaluation={targetEvaluation}
+      chartData={chartData}
+    />
+  );
+}
+
+// {!selectedPeriod ? (
+//   <p className="flex items-center gap-2 text-sm text-muted-foreground">
+//     <Icons.CircleAlert />
+//     評価期間が設定されていません
+//   </p>
+// ) : !targetEvaluation ? (
+//   <p className="flex items-center gap-2 text-sm text-muted-foreground">
+//     <Icons.CircleAlert />
+//     まだ評価が登録されていません
+//   </p>
+// ) : (
+//   <StaffEvaluationSection
+//     selectedPeriod={selectedPeriod}
+//     targetEvaluation={targetEvaluation}
+//     chartData={chartData}
+//   />
+// )}

--- a/src/app/(protected)/admin/staff/[staffId]/page.tsx
+++ b/src/app/(protected)/admin/staff/[staffId]/page.tsx
@@ -6,6 +6,7 @@ import AdminContainer from '../../components/admin-contaimer';
 import { requireAdmin } from '@/lib/utils/requireAdmin';
 import {
   ChartDataPoint,
+  EvaluationPeriod,
   ExistingEvaluation,
   PeriodForChart,
 } from '../../../../../../types/evaluations';
@@ -18,7 +19,7 @@ type StaffDetailPageProps = {
 };
 
 type StaffEvaluationProps = {
-  selectedPeriod?: { id: string; name: string } | null; //TODO: 型をどこで定義するのか？
+  selectedPeriod?: EvaluationPeriod | null;
   targetEvaluation?: ExistingEvaluation | null;
   chartData: ChartDataPoint[];
 };
@@ -173,21 +174,3 @@ function StaffEvaluation({
     />
   );
 }
-
-// {!selectedPeriod ? (
-//   <p className="flex items-center gap-2 text-sm text-muted-foreground">
-//     <Icons.CircleAlert />
-//     評価期間が設定されていません
-//   </p>
-// ) : !targetEvaluation ? (
-//   <p className="flex items-center gap-2 text-sm text-muted-foreground">
-//     <Icons.CircleAlert />
-//     まだ評価が登録されていません
-//   </p>
-// ) : (
-//   <StaffEvaluationSection
-//     selectedPeriod={selectedPeriod}
-//     targetEvaluation={targetEvaluation}
-//     chartData={chartData}
-//   />
-// )}

--- a/types/evaluations.ts
+++ b/types/evaluations.ts
@@ -40,8 +40,8 @@ export type ExistingEvaluationSection = Pick<
 
 export type ExistingEvaluation = Pick<
   Tables<'evaluations'>,
-  'id' | 'status' | 'action_plan' | 'total_comment' | 'future_vision'
-> & { evaluation_sections: ExistingEvaluationSection[] };
+  'id' | 'action_plan' | 'total_comment' | 'future_vision'
+> & { status: Status } & { evaluation_sections: ExistingEvaluationSection[] };
 
 export type ExistingEvaluationForStaffCard = Pick<
   Tables<'evaluations'>,

--- a/types/evaluations.ts
+++ b/types/evaluations.ts
@@ -16,6 +16,11 @@ export type Status = 'completed' | 'draft';
 
 export type FormattedEvaluation = Record<SectionType, SectionData>;
 
+export type EvaluationPeriod = Pick<
+  Tables<'evaluation_periods'>,
+  'id' | 'name'
+>;
+
 export type EvaluationItem = Pick<
   Tables<'evaluation_items'>,
   'item_name' | 'score'


### PR DESCRIPTION
## 概要

close #185

スタッフ評価詳細ページで、下書き保存（status='draft'）した評価が確定済みのように表示される問題を修正。

## 原因

表示の分岐を evaluation の有無だけで判定しており、status を参照していなかった。そのため draft でもデータが存在すれば評価内容が表示されていた。#176・#177・#182 と同じ「status未参照」の問題。

## 変更内容

- 表示分岐に `status === 'draft'` の判定を追加し、下書き中は専用メッセージを表示するよう修正
- ネストした三項演算子を `StaffEvaluation` コンポーネントに切り出し、早期リターンで記述（可読性向上）
- 4つの状態を排他的に分岐
  - 評価期間が未設定 → `selectedPeriod` が無い
  - 評価が未登録 → `evaluation` が無い
  - 下書き中 → `evaluation` が存在し `status === 'draft'`
  - 評価済み → `evaluation` が存在し `status === 'completed'`
- `ExistingEvaluation` 型の `status` を `Status` 型でインターセクションし、補完を有効化（Supabaseの生成型では `string` になるため）Supabase側にてCHECK制約でcompleted/draft以外は入らないように保証済み。
- インラインで書いていた `selectedPeriod` の型を `EvaluationPeriod` として `types/evaluations.ts` に切り出し

## 動作確認

- 下書き保存後に詳細ページを開き、評価内容ではなく「下書き中のため表示できません」が表示されることを確認
- 評価期間未設定・評価未登録・評価済みの各表示も正常に動作することを確認

## 補足

未評価・下書き状態のスタッフへの評価導線（リンク設置）はスコープ外のため、別Issueで対応予定。