### PR TITLE
Refactor/extract dot component

### DIFF
--- a/src/app/(protected)/admin/components/evaluation-section.tsx
+++ b/src/app/(protected)/admin/components/evaluation-section.tsx
@@ -5,6 +5,7 @@ import { Tables } from '../../../../../types/supabase';
 import SectionEvaluationLayout from '@/components/evaluation/section-evaluation-layout';
 import SectionEvaluationDetail from '@/components/evaluation/section-evaluation-detail';
 import { Label } from '@/components/ui/label';
+import SectionTitle from '@/components/shared/section-title';
 import ProgressBar from '@/components/evaluation/progress-bar';
 import { FormattedSectionRate } from '@/lib/utils/evaluation-format';
 import { Staff } from '../../../../../types/staff';
@@ -75,10 +76,7 @@ export default function EvaluationSection({
             </div>
             <EvaluationPeriodSelect evaluationPeriods={evaluationPeriods} />
           </div>
-          <Label>
-            <span className="size-2 bg-primary rounded-full" />
-            店舗全体評価
-          </Label>
+          <SectionTitle>店舗全体評価</SectionTitle>
           <SectionEvaluationLayout>
             <SectionEvaluationDetail
               rank={rank}

--- a/src/app/(protected)/admin/components/staff-list.tsx
+++ b/src/app/(protected)/admin/components/staff-list.tsx
@@ -13,7 +13,7 @@ import { Staff } from '../../../../../types/staff';
 import { Icons } from '@/components/icon/icons';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Label } from '@/components/ui/label';
+import SectionTitle from '@/components/shared/section-title';
 
 type StaffCardProps = {
   staff: Staff;
@@ -38,10 +38,7 @@ export default function StaffList({
   const totalPage = Math.ceil(staffs.length / pageSize);
   return (
     <>
-      <Label>
-        <span className="size-2 bg-primary rounded-full" />
-        {title}
-      </Label>
+      <SectionTitle>{title}</SectionTitle>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
         {currentItems.map((staff) => (
           <StaffCard

--- a/src/app/(protected)/admin/staff/[staffId]/evaluation/components/sumarry.tsx
+++ b/src/app/(protected)/admin/staff/[staffId]/evaluation/components/sumarry.tsx
@@ -4,7 +4,7 @@ import {
   ExistingEvaluationSection,
 } from '../../../../../../../../types/evaluations';
 import { calcEvaluation } from '@/lib/utils/evaluation-calc';
-import { Label } from '@/components/ui/label';
+import SectionTitle from '@/components/shared/section-title';
 import { Icons } from '@/components/icon/icons';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { RANKCOLOR } from '@/lib/constants/rank-color';
@@ -29,10 +29,7 @@ function SectionSummaryCard({ section }: SectionSummaryCardProps) {
   return (
     <TabsContent value={section.section_type}>
       <div className="mt-6 max-w-200 mx-auto">
-        <Label>
-          <span className="size-2 bg-primary rounded-full" />
-          {sectionLabel[section.section_type]}
-        </Label>
+        <SectionTitle>{sectionLabel[section.section_type]}</SectionTitle>
         <Card className="mt-2">
           <CardContent>
             <div className="flex justify-around items-center py-4">
@@ -123,10 +120,7 @@ export default function Summary({ existingEvaluations }: SummaryProps) {
   return (
     <>
       <div className="mt-10 max-w-200 mx-auto">
-        <Label>
-          <span className="size-2 bg-primary rounded-full" />
-          サマリー
-        </Label>
+        <SectionTitle>サマリー</SectionTitle>
         <Card className="mt-2">
           <CardContent className="flex justify-around items-center py-4">
             <div className="flex flex-col flex-1 items-center gap-1 border-r">

--- a/src/components/evaluation/category-radar-chart.tsx
+++ b/src/components/evaluation/category-radar-chart.tsx
@@ -8,7 +8,7 @@ import {
   RadarChart,
   ResponsiveContainer,
 } from 'recharts';
-import { Label } from '../ui/label';
+import SectionTitle from '@/components/shared/section-title';
 import { CHART_COLORS } from '@/lib/constants/chart-colors';
 
 type CategoryRadarChartProps = {
@@ -29,10 +29,7 @@ export default function CategoryRadarChart({
   ];
   return (
     <div>
-      <Label>
-        <span className="size-2 bg-primary rounded-full" />
-        スキルグラフ
-      </Label>
+      <SectionTitle>スキルグラフ</SectionTitle>
       <ResponsiveContainer width="100%" height={300}>
         <RadarChart
           data={data}

--- a/src/components/evaluation/evaluation-line-chart.tsx
+++ b/src/components/evaluation/evaluation-line-chart.tsx
@@ -9,7 +9,7 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
-import { Label } from '../ui/label';
+import SectionTitle from '@/components/shared/section-title';
 import { ChartDataPoint } from '../../../types/evaluations';
 
 type EvaluationLineChart = {
@@ -21,10 +21,7 @@ export default function EvaluationLineChart({
 }: EvaluationLineChart) {
   return (
     <div>
-      <Label>
-        <span className="size-2 bg-primary rounded-full" />
-        総合達成率推移グラフ
-      </Label>
+      <SectionTitle>総合達成率推移グラフ</SectionTitle>
       <span className="text-muted-foreground text-[8px] sm:text-[10px]">
         ※最新から過去4件のデータを表示
       </span>

--- a/src/components/evaluation/progress-bar.tsx
+++ b/src/components/evaluation/progress-bar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Label } from '../ui/label';
+import SectionTitle from '@/components/shared/section-title';
 
 type ProgressBarProps = {
   label: string;
@@ -10,10 +10,7 @@ type ProgressBarProps = {
 export default function ProgressBar({ label, sectionRates }: ProgressBarProps) {
   return (
     <div className="lg:flex-1">
-      <Label>
-        <span className="size-2 bg-primary rounded-full" />
-        {label}
-      </Label>
+      <SectionTitle>{label}</SectionTitle>
       <div className="mt-5  border rounded-xl p-5 sm:p-8">
         <div className="space-y-5">
           {sectionRates.map((section) => (

--- a/src/components/evaluation/rate-circle-chart.tsx
+++ b/src/components/evaluation/rate-circle-chart.tsx
@@ -2,7 +2,7 @@
 
 import { CHART_COLORS } from '@/lib/constants/chart-colors';
 import { Pie, PieChart } from 'recharts';
-import { Label } from '../ui/label';
+import SectionTitle from '@/components/shared/section-title';
 
 type RateCircleChartProps = {
   rate: number;
@@ -12,10 +12,7 @@ export default function RateCircleChart({ rate }: RateCircleChartProps) {
   const endAngle = 90 - 360 * (rate / 100);
   return (
     <div className="relative flex items-center justify-center p-5">
-      <Label className="absolute top-0 left-0">
-        <span className="size-2 bg-primary rounded-full" />
-        達成率
-      </Label>
+      <SectionTitle className="absolute top-0 left-0">達成率</SectionTitle>
       <PieChart width={200} height={200}>
         <Pie
           data={[{ value: 100 }]}

--- a/src/components/evaluation/section-tab.tsx
+++ b/src/components/evaluation/section-tab.tsx
@@ -12,7 +12,7 @@ import {
   EvaluationItemConstant,
   Category,
 } from '../../../types/evaluations';
-import { Label } from '../ui/label';
+import SectionTitle from '@/components/shared/section-title';
 import { useState } from 'react';
 import {
   filterEvaluationItemsByCategory,
@@ -62,10 +62,7 @@ export default function SectionTab({
 
   return (
     <div>
-      <Label>
-        <span className="size-2 bg-primary rounded-full" />
-        各セクション詳細スコア
-      </Label>
+      <SectionTitle>各セクション詳細スコア</SectionTitle>
       <Tabs
         defaultValue="skill"
         className="mt-8"

--- a/src/components/shared/section-title.tsx
+++ b/src/components/shared/section-title.tsx
@@ -1,0 +1,19 @@
+import { ReactNode } from 'react';
+import { Label } from '@/components/ui/label';
+
+type SectionTitleProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+export default function SectionTitle({
+  children,
+  className,
+}: SectionTitleProps) {
+  return (
+    <Label className={className}>
+      <span className="size-2 bg-primary rounded-full" />
+      {children}
+    </Label>
+  );
+}


### PR DESCRIPTION
## 概要
複数箇所で重複していたドット付き見出し(`<Label> + ドット + テキスト`)を共通コンポーネントSectionTitleに集約した。

## 設計判断
- 補足テキスト(チャート注釈)は見出しとは関心が異なるため、SectionTitleには含めず呼び出し側に残した
- classNameをpropsで受け取れるようにし、絶対配置が必要な箇所y(rate-circle-chart)に対応した

## 開発手法
Claude Code を使用。丸投げせず、洗い出し → 構造調査 → 設計 → 段階的な置き換え の順で、各ステップの出力を確認しながら進めた。

## 確認
- npm run check(lint + typecheck)通過
- 全9箇所の見た目が変わっていないことを目視確認 