### PR TITLE
feat: CLAUDE.mdに型定義はtypeで統一するように追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,3 +111,7 @@ react-hook-form + Zod throughout. Server Actions handle mutations (files named `
 
 - **Server Components**: デフォルト(async 可能、データ取得可能)
 - **Client Components**: `"use client"`ディレクティブ付き(インタラクション、状態管理)
+
+### 型定義
+
+- 型定義は type で統一する(interface は使わない)


### PR DESCRIPTION
## 概要
CLAUDE.mdに型定義はtypeで統一し、interfaceは使用しないように記述した。

## 設計理由
interfaceはdeclaration mergingにより、同名を再宣言すると意図せず型がマージ・拡張されるリスクがある。
一方typeは再宣言でエラーになるので、変更が必ず明示的になる。

また、typeはユニオン型・交差型・Pick/Omitなど幅広い型を表現できる。
本アプリケーションでは以下の記述を多用しています。

ユニオン型
```ts

export type Category = 'skill' | 'hospitality' | 'cleanliness';

```

Databaseの自動生成型からPick

```ts
export type EvaluationItem = Pick<
  Tables<'evaluation_items'>,
  'item_name' | 'score'
> & {
  category: Category;
};
```

ユニオン型はinterfaceには無い機能で、Pickや合成はinterfaceでも部分的に可能だがtypeの方が自然で制約が少ないのでtypeを採用した。