### PR TITLE
Test/feedback agent

### DIFF
--- a/src/agents/feedback/calc-cost.test.ts
+++ b/src/agents/feedback/calc-cost.test.ts
@@ -1,0 +1,17 @@
+import { calcCost } from './calc-cost';
+
+describe('calcCost', () => {
+  it('haikuのトークン数からコストを算出する', () => {
+    const MODEL = 'claude-haiku-4-5';
+    const input_tokens = 850;
+    const output_tokens = 90;
+    const expected = 0.0013;
+
+    const result = calcCost(MODEL, input_tokens, output_tokens);
+
+    expect(result).toBeCloseTo(expected);
+  });
+  it('未知のモデルは0を返す', () => {
+    expect(calcCost('unknown-model', 1000, 1000)).toBe(0);
+  });
+});

--- a/src/agents/feedback/format-evaluation.test.ts
+++ b/src/agents/feedback/format-evaluation.test.ts
@@ -1,0 +1,80 @@
+import { ExistingEvaluation } from '../../../types/evaluations';
+import { CurrentEvaluation } from './types';
+import { formatCurrentEvaluation } from './format-evaluation';
+
+describe('formatCurrentEvaluation', () => {
+  it('評価データを期待したデータに変換できる', () => {
+    const input: ExistingEvaluation = {
+      id: 'eval-1',
+      status: 'completed',
+      action_plan: 'お客様に笑顔で接する',
+      total_comment: 'よくがんばっている',
+      future_vision: 'ドリンク作成が上手なるようにしましょう',
+      evaluation_sections: [
+        {
+          section_type: 'basic',
+          good_points: ['good-1'],
+          improvement_points: ['improve-1'],
+          skill_score: 3,
+          skill_max: 4,
+          hospitality_score: 4,
+          hospitality_max: 4,
+          cleanliness_score: 4,
+          cleanliness_max: 4,
+          evaluation_items: [
+            { item_name: 'item-1', category: 'skill', score: 3 },
+            { item_name: 'item-2', category: 'hospitality', score: 4 },
+            { item_name: 'item-3', category: 'cleanliness', score: 4 },
+          ],
+        },
+        {
+          section_type: 'barista',
+          good_points: ['good-2'],
+          improvement_points: ['improve-2'],
+          skill_score: 4,
+          skill_max: 4,
+          hospitality_score: 3,
+          hospitality_max: 4,
+          cleanliness_score: 4,
+          cleanliness_max: 4,
+          evaluation_items: [
+            { item_name: 'item-4', category: 'skill', score: 4 },
+            { item_name: 'item-5', category: 'hospitality', score: 3 },
+            { item_name: 'item-6', category: 'cleanliness', score: 4 },
+          ],
+        },
+        {
+          section_type: 'cashier',
+          good_points: ['good-3'],
+          improvement_points: ['improve-3'],
+          skill_score: 4,
+          skill_max: 4,
+          hospitality_score: 4,
+          hospitality_max: 4,
+          cleanliness_score: 3,
+          cleanliness_max: 4,
+          evaluation_items: [
+            { item_name: 'item-7', category: 'skill', score: 4 },
+            { item_name: 'item-8', category: 'hospitality', score: 4 },
+            { item_name: 'item-9', category: 'cleanliness', score: 3 },
+          ],
+        },
+      ],
+    };
+
+    const expected: CurrentEvaluation = {
+      skillRate: 91,
+      hospitalityRate: 91,
+      cleanlinessRate: 91,
+      totalRate: 91,
+      rank: 'A',
+      actionPlan: 'お客様に笑顔で接する',
+      totalComment: 'よくがんばっている',
+      futureVision: 'ドリンク作成が上手なるようにしましょう',
+    };
+
+    const result = formatCurrentEvaluation(input);
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/agents/feedback/format-evaluation.test.ts
+++ b/src/agents/feedback/format-evaluation.test.ts
@@ -2,6 +2,57 @@ import { ExistingEvaluation } from '../../../types/evaluations';
 import { CurrentEvaluation } from './types';
 import { formatCurrentEvaluation } from './format-evaluation';
 
+const sections: ExistingEvaluation['evaluation_sections'] = [
+  {
+    section_type: 'basic',
+    good_points: ['good-1'],
+    improvement_points: ['improve-1'],
+    skill_score: 3,
+    skill_max: 4,
+    hospitality_score: 4,
+    hospitality_max: 4,
+    cleanliness_score: 4,
+    cleanliness_max: 4,
+    evaluation_items: [
+      { item_name: 'item-1', category: 'skill', score: 3 },
+      { item_name: 'item-2', category: 'hospitality', score: 4 },
+      { item_name: 'item-3', category: 'cleanliness', score: 4 },
+    ],
+  },
+  {
+    section_type: 'barista',
+    good_points: ['good-2'],
+    improvement_points: ['improve-2'],
+    skill_score: 4,
+    skill_max: 4,
+    hospitality_score: 3,
+    hospitality_max: 4,
+    cleanliness_score: 4,
+    cleanliness_max: 4,
+    evaluation_items: [
+      { item_name: 'item-4', category: 'skill', score: 4 },
+      { item_name: 'item-5', category: 'hospitality', score: 3 },
+      { item_name: 'item-6', category: 'cleanliness', score: 4 },
+    ],
+  },
+  {
+    section_type: 'cashier',
+    good_points: ['good-3'],
+    improvement_points: ['improve-3'],
+    skill_score: 4,
+    skill_max: 4,
+    hospitality_score: 4,
+    hospitality_max: 4,
+    cleanliness_score: 3,
+    cleanliness_max: 4,
+    evaluation_items: [
+      { item_name: 'item-7', category: 'skill', score: 4 },
+      { item_name: 'item-8', category: 'hospitality', score: 4 },
+      { item_name: 'item-9', category: 'cleanliness', score: 3 },
+    ],
+  },
+];
+
 describe('formatCurrentEvaluation', () => {
   it('評価データを期待したデータに変換できる', () => {
     const input: ExistingEvaluation = {
@@ -10,56 +61,7 @@ describe('formatCurrentEvaluation', () => {
       action_plan: 'お客様に笑顔で接する',
       total_comment: 'よくがんばっている',
       future_vision: 'ドリンク作成が上手なるようにしましょう',
-      evaluation_sections: [
-        {
-          section_type: 'basic',
-          good_points: ['good-1'],
-          improvement_points: ['improve-1'],
-          skill_score: 3,
-          skill_max: 4,
-          hospitality_score: 4,
-          hospitality_max: 4,
-          cleanliness_score: 4,
-          cleanliness_max: 4,
-          evaluation_items: [
-            { item_name: 'item-1', category: 'skill', score: 3 },
-            { item_name: 'item-2', category: 'hospitality', score: 4 },
-            { item_name: 'item-3', category: 'cleanliness', score: 4 },
-          ],
-        },
-        {
-          section_type: 'barista',
-          good_points: ['good-2'],
-          improvement_points: ['improve-2'],
-          skill_score: 4,
-          skill_max: 4,
-          hospitality_score: 3,
-          hospitality_max: 4,
-          cleanliness_score: 4,
-          cleanliness_max: 4,
-          evaluation_items: [
-            { item_name: 'item-4', category: 'skill', score: 4 },
-            { item_name: 'item-5', category: 'hospitality', score: 3 },
-            { item_name: 'item-6', category: 'cleanliness', score: 4 },
-          ],
-        },
-        {
-          section_type: 'cashier',
-          good_points: ['good-3'],
-          improvement_points: ['improve-3'],
-          skill_score: 4,
-          skill_max: 4,
-          hospitality_score: 4,
-          hospitality_max: 4,
-          cleanliness_score: 3,
-          cleanliness_max: 4,
-          evaluation_items: [
-            { item_name: 'item-7', category: 'skill', score: 4 },
-            { item_name: 'item-8', category: 'hospitality', score: 4 },
-            { item_name: 'item-9', category: 'cleanliness', score: 3 },
-          ],
-        },
-      ],
+      evaluation_sections: sections,
     };
 
     const expected: CurrentEvaluation = {
@@ -71,6 +73,32 @@ describe('formatCurrentEvaluation', () => {
       actionPlan: 'お客様に笑顔で接する',
       totalComment: 'よくがんばっている',
       futureVision: 'ドリンク作成が上手なるようにしましょう',
+    };
+
+    const result = formatCurrentEvaluation(input);
+
+    expect(result).toEqual(expected);
+  });
+
+  it('コメントが未記入の場合nullが返るか', () => {
+    const input: ExistingEvaluation = {
+      id: 'eval-1',
+      status: 'completed',
+      action_plan: null,
+      total_comment: null,
+      future_vision: null,
+      evaluation_sections: sections,
+    };
+
+    const expected: CurrentEvaluation = {
+      skillRate: 91,
+      hospitalityRate: 91,
+      cleanlinessRate: 91,
+      totalRate: 91,
+      rank: 'A',
+      actionPlan: null,
+      totalComment: null,
+      futureVision: null,
     };
 
     const result = formatCurrentEvaluation(input);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
+import path from 'path';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
   test: {
     globals: true,
     environment: 'node',


### PR DESCRIPTION
## 概要
エージェント関連の純粋関数にユニットテストを追加。

- judgeDirection（既存）
- formatCurrentEvaluation（正常系 / null ケース）
- calcCost（算出 / 未知モデル）

あわせて vitest.config.ts にパスエイリアス（@ → src）を追加し、
@/ を使うモジュールのテストを実行できるようにした。

## 補足
Supabase や Anthropic API に依存する部分（queries.ts / actions.ts）は
モックが必要なため、今回は対象外とし動作確認で担保している。