### PR TITLE
fix: 評価期間一覧の並び順を保証する(#199)

### DIFF
--- a/src/app/(protected)/admin/page.tsx
+++ b/src/app/(protected)/admin/page.tsx
@@ -29,7 +29,8 @@ export default async function AdminPage() {
     supabase
       .from('evaluation_periods')
       .select('id, name, is_current')
-      .eq('organization_id', orgId),
+      .eq('organization_id', orgId)
+      .order('created_at', { ascending: true }),
   ]);
 
   if (staffError) redirect('/admin');


### PR DESCRIPTION
## 概要

evaluation_periods取得クエリに.order()句がないため順序が不安定に取得される。

## 対応
- evaluation_periods取得クエリに`.order('created_at', { ascending: tur })`を追加

## 残る問題
今回の対応は「登録した順番」を保証するもの。created_atは評価期間そのものの日付ではなく、登録日時なので、過去の評価を後から追加登録するようなケースでは、時系列としては意図と異なる。
今後はDB設計の修正が必要になる。
