### PR TITLE
fix: editStaffがstaffIdの所有権チェック前にservice-roleでメール更新していた問題を修正(#204)

### DIFF
--- a/src/app/(protected)/admin/staff/actions.ts
+++ b/src/app/(protected)/admin/staff/actions.ts
@@ -67,6 +67,15 @@ export async function editStaff(data: EditStaffInput, staffId: string) {
 
   const { orgId } = await requireAdmin(supabase);
 
+  const { data: staff, error: staffError } = await supabase
+    .from('profiles')
+    .select('id')
+    .eq('id', staffId)
+    .eq('organization_id', orgId)
+    .single();
+
+  if (staffError || !staff) throw new Error('スタッフが見つかりません');
+
   const validated = editStaffSchema.safeParse(data);
   if (!validated.success) throw new Error('入力内容を確認してください');
 


### PR DESCRIPTION
## 概要

`editStaff`に渡された`staffId`が呼び出し管理者の組織に属するかをチェックする前に、service-roleクライアントで`auth.admin.updateUserById`を呼び出しており、任意の他組織ユーザーのログインメールアドレスを書き換える状態だった。

## 原因

`requireAdmin` は呼び出し元が「いずれかの組織の管理者」であることのみを保証し、引数で渡された `staffId` がその管理者の組織に属するかは保証しない。service-role クライアントはRLSをバイパスするため、所有権チェックより先に呼ぶと組織を跨いで任意ユーザーの認証情報を書き換えられる。

## 対応

- `updateUserById` を呼ぶ前に、`profiles` から `staffId` + `orgId` で所有権を確認するチェックを追加(`deleteStaff` / `editStaffPassword` と同じパターン)

## 検証

ローカル環境にOrg A / Org Bの2組織を用意し、実際にブラウザが送信するServer ActionのHTTPリクエストを捕まえて `staffId` を他組織のものに差し替える形で攻撃を再現・検証した。

- **修正前**: Org A管理者のセッションのまま、Org Bスタッフの認証用メールアドレス(ログインに使う実際のメール)が書き換わることを確認。`profiles` 側の表示名・表示用メールは変化せず、画面上は気づけない状態だった。
- **修正後**: 同じリクエストが `スタッフが見つかりません` で拒否され、対象のメールアドレスは変化しないことを確認。
- 既存の lint / typecheck / vitest(21件)はすべてパス。

## 影響範囲・重大度の補足

- `staffId` にロール制約が無いため、被害はスタッフに限らず**他組織の管理者アカウント**にも及び得る(組織全体のデータにアクセス可能)。
- 管理者アカウントは招待制ではなく自己登録可能なため、攻撃者になるためのハードルは低い。
- 書き換え後にパスワードリセットを行えば、被害アカウントへの完全ななりすましが可能。

Closes #204