### PR TITLE
fix: uploadStaffAvatarに認可チェックが無く任意ユーザーが他ユーザーのアバターを上書きできた問題を修正(#207)

### DIFF
--- a/src/lib/utils/upload.ts
+++ b/src/lib/utils/upload.ts
@@ -2,19 +2,23 @@
 
 import { createAdminClient } from '../supabase/admin';
 import { createClient } from '../supabase/server';
+import { requireAdmin } from './requireAdmin';
 import { AVATAR_ALLOWED_TYPES, AVATAR_MAX_SIZE } from '@/lib/constants/upload';
 
 export async function uploadStaffAvatar(formData: FormData, staffId: string) {
   const supabase = await createClient();
   const supabaseAdmin = createAdminClient();
 
-  const {
-    data: { user },
-    error: authError,
-  } = await supabase.auth.getUser();
+  const { orgId } = await requireAdmin(supabase);
 
-  if (authError) throw new Error('認証エラーが発生しました');
-  if (!user) throw new Error('認証エラーが発生しました');
+  const { data: staff, error: staffError } = await supabase
+    .from('profiles')
+    .select('id')
+    .eq('id', staffId)
+    .eq('organization_id', orgId)
+    .single();
+
+  if (staffError || !staff) throw new Error('スタッフが見つかりません');
 
   const file = formData.get('avatar');
   if (!(file instanceof File)) throw new Error('ファイルが選択されていません');


### PR DESCRIPTION
## 概要

`uploadStaffAvataor`(`src/lib/utils/upload.ts`)は認証済みであることしか確認しておらず、管理者権限チェック、staffIdの所属組織チェックが一切無かった。
認証済みの任意のユーザー(スタッフ含む)が、任意の`staffId`を指定して他ユーザー(他組織の管理者も含む)の`avatar_url`をservice-role経由で上書きできる状態だった。

## 原因

- `requireAdmin()`の呼び出しが無く、役割チェックが無かった
- `staffId`が呼び出しユーザーの`organization_id`配下かの確認が無かった
- service-roleクライアント(`supabaseAdmin`)でstorageアップロードと`profiles`更新を両方実行しており、RLSも効かない状態だった

## 対応

`editStaff`(#204)と同じパターンで、`requireAdmin()`による管理者チェックと、`staffId`が呼び出し管理者の`organization_id`配下であることの確認を追加した。

- `requireAdmin(supabase)`で管理者ロールであることを確認し`orgId`を取得
- `profiles`を`id`(`staffId`) + `organization_id`(`orgId`)で照合し、一致しなければ`スタッフが見つかりません`で処理を中断
- 上記チェックを通過した場合のみ、従来通り`supabaseAdmin`でstorageアップロード・`profiles.avatar_url`更新を行う

## 検証

- lint / typecheck はパス
- ローカル環境での実攻撃再現(他組織の`staffId`を指定したリクエストの再現)は未実施

## 影響範囲・重大度の補足

- 管理者である必要すらなく、最も権限の低いスタッフアカウントでも呼び出せた
- `staffId`にロール・組織の制約が無いため、被害はシステム内の任意ユーザー(他組織の管理者含む)に及び得た
- 書き換え対象は`profiles.avatar_url`で、相手の画面(プロフィール、管理者の一覧画面など)に直接表示されるため、なりすまし表示・嫌がらせに悪用され得た

Closes #207