### PR TITLE
fix: サインアップのuser_metadataからrole/organization_idを無検証で信用していた問題を修正 (#218)

### DIFF
--- a/src/app/(protected)/admin/staff/actions.ts
+++ b/src/app/(protected)/admin/staff/actions.ts
@@ -22,20 +22,34 @@ export async function addStaff(data: AddStaffInput) {
   const validated = addStaffSchema.safeParse(data);
   if (!validated.success) throw new Error('入力内容を確認してください');
 
-  const { error } = await supabaseAdmin.auth.admin.createUser({
+  const { data: created, error } = await supabaseAdmin.auth.admin.createUser({
     email: validated.data.email,
     password: validated.data.password,
     email_confirm: true,
     user_metadata: {
       name: validated.data.name,
-      role: 'staff',
-      organization_id: orgId,
       store_name: adminProfile.store_name,
-      is_setup_complete: true,
     },
   });
 
-  if (error) throw new Error('スタッフの登録に失敗しました');
+  if (error || !created.user) throw new Error('スタッフの登録に失敗しました');
+
+  // handle_new_user() トリガーは role/organization_id をメタデータから信用しないため
+  // (未検証のクライアント入力による組織侵入を防ぐため)、常に admin・新規組織で作成される。
+  // requireAdmin() で権限検証済みのこの経路から、正しい role/organization_id に確定する。
+  const { error: profileError } = await supabaseAdmin
+    .from('profiles')
+    .update({
+      role: 'staff',
+      organization_id: orgId,
+      is_setup_complete: true,
+    })
+    .eq('id', created.user.id);
+
+  if (profileError) {
+    await supabaseAdmin.auth.admin.deleteUser(created.user.id);
+    throw new Error('スタッフの登録に失敗しました');
+  }
 
   revalidatePath('/admin/staff');
 }

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -30,8 +30,6 @@ export function useAuth() {
   const signUp = async (data: SignupInput) => {
     setIsLoading((prev) => ({ ...prev, signUp: true }));
     try {
-      const organizationId = crypto.randomUUID();
-
       const { error } = await supabase.auth.signUp({
         email: data.email,
         password: data.password,
@@ -39,8 +37,6 @@ export function useAuth() {
           data: {
             name: data.name,
             store_name: data.storeName,
-            role: 'admin',
-            organization_id: organizationId,
           },
           emailRedirectTo: `${window.location.origin}/login`,
         },

--- a/supabase/migrations/20260728030244_fix_handle_new_user_untrusted_metadata.sql
+++ b/supabase/migrations/20260728030244_fix_handle_new_user_untrusted_metadata.sql
@@ -1,0 +1,43 @@
+-- handle_new_user() は auth.users への INSERT で発火する SECURITY DEFINER トリガーであり、
+-- RLS を経由せず profiles に書き込める唯一の境界だった。
+-- これまでは raw_user_meta_data の role / organization_id をそのまま信用していたため、
+-- クライアントが supabase.auth.signUp() を直接叩き、既存組織の organization_id と
+-- role: 'admin' を指定するだけで、承認なしに他組織へ admin として侵入できてしまっていた。
+--
+-- このトリガーは公開サインアップ(supabase.auth.signUp)と、
+-- 管理者によるスタッフ作成(supabaseAdmin.auth.admin.createUser、addStaff() 内)の
+-- 両方で共用されており、DB 側からは呼び出し元の信頼レベルを区別できない。
+-- そのため role / organization_id は常に安全側のデフォルト(新規組織の admin)に固定し、
+-- スタッフ作成時の正しい role / organization_id への上書きは、
+-- requireAdmin() で権限検証済みのサーバー側(addStaff())が明示的に行う。
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_is_setup_complete BOOLEAN;
+BEGIN
+  v_is_setup_complete := (
+    NEW.raw_user_meta_data->>'name' IS NOT NULL
+    AND NEW.raw_user_meta_data->>'store_name' IS NOT NULL
+  );
+
+  INSERT INTO public.profiles (
+    id,
+    email,
+    name,
+    role,
+    store_name,
+    organization_id,
+    is_setup_complete
+  )
+  VALUES (
+    NEW.id,
+    NEW.email,
+    COALESCE(NEW.raw_user_meta_data->>'name', '名前未設定'),
+    'admin',
+    COALESCE(NEW.raw_user_meta_data->>'store_name', '店舗名未設定'),
+    gen_random_uuid(),
+    v_is_setup_complete
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
## 概要

`handle_new_user()`トリガー(SECURITY DEFINER)が`auth.users.raw_user_meta_data`のroleとorganization_idを無検証でprofilesにコピーしていたのでsupabase.auth.signUp()を直接叩き既存の組織のorganization_idとrole: adminを指定するだけで、承認なしに他組織へadminとして侵入できた。

## 対応
- トリガーはこのフィールドを常に安全なデフォルト(`role = 'admin'`, `organization_id =
  gen_random_uuid()`)に固定し、クライアント入力を一切信用しないよう修正
- 公開サインアップと、管理者によるスタッフ作成(`addStaff()` → `supabaseAdmin.auth.admin.createUser()`)
  の両方で共用されており、DB側からは呼び出し元の信頼レベルを区別できないため、正しい `role`/`organization_id`
  への確定は `requireAdmin()` で権限検証済みの `addStaff()` 側が `createUser()` 成功後に明示的な `UPDATE`
  で行う方式に変更
- `profiles` の `UPDATE` に失敗した場合は、作成済みauthユーザーをロールバック削除し、不整合な(admin・ランダム組織の)
  アカウントが残らないようにした
  - 上記に伴い、`useAuth().signUp()` が送っていた(トリガーが今後無視する)`role`/`organization_id` の送信を削除

Closes #218