### PR TITLE
fix: profilesのUPDATE RLSがrole/organization_idを列制限せず権限昇格を許していた問題を修正

### DIFF
--- a/supabase/migrations/20260728084115_restrict_profiles_role_org_columns.sql
+++ b/supabase/migrations/20260728084115_restrict_profiles_role_org_columns.sql
@@ -1,0 +1,52 @@
+-- #217 対応: profilesのUPDATE RLSに列制限が無く、
+-- staffが自分自身のrole/organization_idを書き換えて権限昇格できる問題を修正する
+
+-- ヘルパー関数: 呼び出しユーザーがadminかどうかを判定する
+-- (profilesのポリシー内でprofilesをEXISTSで直接参照すると無限再帰になるため、
+--  get_user_organization_id()と同様にSECURITY DEFINER関数として切り出す)
+CREATE OR REPLACE FUNCTION public.is_admin()
+RETURNS BOOLEAN AS $$
+BEGIN
+  RETURN (
+    SELECT role = 'admin'
+    FROM public.profiles
+    WHERE id = auth.uid()
+    LIMIT 1
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- "Users can update organization profiles"(同一組織・自分以外を対象)に
+-- role='admin'チェックが無く、staffが他ユーザーの行を書き換えられたため、
+-- 本来の意図(adminのみが同一組織の他ユーザーを更新できる)に条件を戻す
+DROP POLICY IF EXISTS "Users can update organization profiles" ON profiles;
+
+CREATE POLICY "Users can update organization profiles"
+ON profiles
+FOR UPDATE
+USING (
+  organization_id = public.get_user_organization_id()
+  AND id != auth.uid()
+  AND public.is_admin()
+)
+WITH CHECK (
+  organization_id = public.get_user_organization_id()
+  AND id != auth.uid()
+  AND public.is_admin()
+);
+
+-- RLSは行単位の制御であり列は区別できないため、
+-- "User can  update own profile"(自分の行)経由でrole/organization_idまで
+-- 書き換え可能になっていた。列単位のGRANTでauthenticatedロールから
+-- role/organization_id/is_demoへの書き込み自体を禁止する。
+-- (role/organization_idを書き込む唯一の正規フローはaddStaff()で、
+--  service_roleクライアント経由のためこの制限の影響を受けない)
+REVOKE UPDATE ON public.profiles FROM authenticated;
+
+GRANT UPDATE (
+  name,
+  store_name,
+  email,
+  avatar_url,
+  is_setup_complete
+) ON public.profiles TO authenticated;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -279,6 +279,7 @@ export type Database = {
     }
     Functions: {
       get_user_organization_id: { Args: never; Returns: string }
+      is_admin: { Args: never; Returns: boolean }
     }
     Enums: {
       [_ in never]: never


### PR DESCRIPTION
## 概要

Closes #217

`profiles`テーブルのUPDATE RLSに列単位の制限が無く、staffが自分自身の`role`/`organization_id`を書き換えて任意組織のadminに昇格できた問題を修正する。

## 原因

- `"User can  update own profile"`ポリシー(`auth.uid() = id`のみ)には列制限が無く、自分の行であればrole/organization_idも含め任意の列を書き換え可能だった
- `"Users can update organization profiles"`ポリシー(同一組織・自分以外)にも本来あったはずの`role = 'admin'`チェックが、無限再帰対策のリファクタ(`20260213144534_fix_rls_policies_infinite_recursion.sql`)で落ちており、staffが他ユーザーの行も自由に更新できた

## 対応

1. `is_admin()`ヘルパー関数(SECURITY DEFINER)を追加し、`"Users can update organization profiles"`に`role = 'admin'`条件を復元
2. `authenticated`ロールのUPDATE権限を列単位に制限
   - `REVOKE UPDATE ON public.profiles FROM authenticated`
   - `GRANT UPDATE (name, store_name, email, avatar_url, is_setup_complete) ON public.profiles TO authenticated`
   - `role` / `organization_id` / `is_demo` はDB権限レベルでauthenticatedから書き込み不可に(RLS条件の書き漏れに依存しない防御)
   - role/organization_idを書き込む唯一の正規フロー(`addStaff()`)は`service_role`クライアント経由のため影響を受けないことをコード上で確認済み

## Test plan

- [x] ローカルSupabaseにmigration適用
- [x] SQLで攻撃再現: staffが自分の`role`/`organization_id`を書き換えようとすると`permission denied for table profiles`で拒否されることを確認
- [x] SQLで正常系確認: staffが自分の`name`を更新できる / staffが他staffの`name`を更新しようとすると拒否される(0件更新) / adminが他staffの`name`を更新できる
- [x] `npm run check`(lint + typecheck)
- [x] `npm run test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)