### PR TITLE
fix: profilesのDELETE RLSがroleチェックを欠いておりstaffが他ユーザーを削除できた問題を修正

### DIFF
--- a/supabase/migrations/20260729061729_restrict_profiles_delete_role_check.sql
+++ b/supabase/migrations/20260729061729_restrict_profiles_delete_role_check.sql
@@ -1,0 +1,18 @@
+-- #219 対応: profilesのDELETE RLSにroleチェックが無く、
+-- staffが同じ組織の他ユーザー(admin含む)のprofile行を削除できる問題を修正する
+--
+-- "Users can delete organization profiles"は無限再帰対策のリファクタ
+-- (20260213144534_fix_rls_policies_infinite_recursion.sql)で作り直された際、
+-- 元々あったrole='admin'チェックが失われていた。#217で追加したis_admin()を
+-- 再利用して条件を復元する。
+
+DROP POLICY IF EXISTS "Users can delete organization profiles" ON profiles;
+
+CREATE POLICY "Users can delete organization profiles"
+ON profiles
+FOR DELETE
+USING (
+  organization_id = public.get_user_organization_id()
+  AND id != auth.uid()
+  AND public.is_admin()
+);


### PR DESCRIPTION
## 概要

Closes #219

`profiles`のDELETE RLSポリシーにroleチェックが無く、staffが同じ組織の他staff・adminの`profiles`行を直接削除できる問題を修正する。#217(UPDATEポリシー)と同根の問題。

## 原因

`"Users can delete organization profiles"`ポリシー(同一組織・自分以外)が、無限再帰対策のリファクタ(`20260213144534_fix_rls_policies_infinite_recursion.sql`)で作り直された際、元々あった`role = 'admin'`チェックを失っていた。

## 影響

正規の削除経路(`deleteStaff`)はservice-role経由で`auth.admin.deleteUser`を呼び、`auth.users`ごと削除する(`ON DELETE CASCADE`で`profiles`も連動して消える)。一方この脆弱性を突くと`profiles`行だけが直接消え、`auth.users`のアカウントは残ったままになる。対象ユーザーは「認証はできるがプロフィールが存在しない」壊れた状態になり、ログイン後に操作不能になる(内部妨害・アカウント破壊のシナリオ)。

## 対応

#217で追加した`is_admin()`ヘルパー(SECURITY DEFINER)を再利用し、DELETEポリシーに`role = 'admin'`条件を復元した。

```sql
CREATE POLICY "Users can delete organization profiles"
ON profiles FOR DELETE
USING (
  organization_id = public.get_user_organization_id()
  AND id != auth.uid()
  AND public.is_admin()
);
```

## Test plan

- [x] ローカルSupabaseにmigration適用
- [x] SQLで攻撃再現: staffが同一組織の他staff/adminを削除しようとすると`DELETE 0`(拒否)されることを確認
- [x] SQLで正常系確認: adminは同一組織のstaffを削除できることを確認
- [x] `npm run check`(lint + typecheck)
- [x] `npm run test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)