### PR TITLE
fix: profilesのSELECT RLSがroleチェックを欠いておりstaffが同一組織の全行を閲覧できた問題を修正

### DIFF
--- a/supabase/migrations/20260729063217_restrict_profiles_select_role_check.sql
+++ b/supabase/migrations/20260729063217_restrict_profiles_select_role_check.sql
@@ -1,0 +1,18 @@
+-- #222 対応: profilesのSELECT RLSにroleチェックが無く、
+-- staffが同じ組織の他ユーザー(admin含む)のprofile行を閲覧できる問題を修正する
+--
+-- "Users can view organization profiles"は無限再帰対策のリファクタ
+-- (20260213144534_fix_rls_policies_infinite_recursion.sql)で作り直された際、
+-- 元々あったrole='admin'チェックが失われていた。自分の行は
+-- "Users can view own profile"で既にカバーされているため、
+-- こちらには#217で追加したis_admin()を条件として足すだけでよい。
+
+DROP POLICY IF EXISTS "Users can view organization profiles" ON profiles;
+
+CREATE POLICY "Users can view organization profiles"
+ON profiles
+FOR SELECT
+USING (
+  organization_id = public.get_user_organization_id()
+  AND public.is_admin()
+);


### PR DESCRIPTION
## 概要

Closes #222

`profiles`のSELECT RLSポリシーにroleチェックが無く、staffが同じ組織の他staff・adminの`profiles`行(email等の個人情報含む)をSELECTできる問題を修正する。#217(UPDATE)・#219(DELETE)と同根の問題。

## 原因

`"Users can view organization profiles"`ポリシー(同一組織)が、無限再帰対策のリファクタ(`20260213144534_fix_rls_policies_infinite_recursion.sql`)で作り直された際、元々あった`role = 'admin'`チェックを失っていた。自分自身の行の閲覧は別ポリシー`"Users can view own profile"`(`auth.uid() = id`)で正しくカバーされているため、影響を受けるのは「他人の行」の閲覧のみ。

## 影響

staffが`supabase.from('profiles').select('*')`を直接叩くと、`organization_id`が一致する同僚staffやadminのprofile行(email, name, avatar_url, roleなど)を丸ごと取得できてしまう。UIには到達経路が無いが、Supabase JSクライアントやPostgRESTへの直接リクエストで到達できる。

## 対応

#217で追加した`is_admin()`ヘルパー(SECURITY DEFINER)を再利用し、SELECTポリシーに`role = 'admin'`条件を追加した。

```sql
CREATE POLICY "Users can view organization profiles"
ON profiles FOR SELECT
USING (
  organization_id = public.get_user_organization_id()
  AND public.is_admin()
);
```

## Test plan

- [x] ローカルSupabaseにmigration適用
- [x] SQLで攻撃再現: staffが`select('*')`しても自分の行しか返らないことを確認
- [x] SQLで正常系確認: adminは同一組織の全行(admin自身+全staff)を閲覧できることを確認
- [x] `npm run check`(lint + typecheck)
- [x] `npm run test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)