### PR TITLE
fix: evaluation_periodsのSELECTポリシー名が実態(admin限定ではない)と食い違っていた問題を修正

### DIFF
--- a/supabase/migrations/20260729072303_rename_evaluation_periods_select_policy.sql
+++ b/supabase/migrations/20260729072303_rename_evaluation_periods_select_policy.sql
@@ -1,0 +1,21 @@
+-- #223 対応: evaluation_periodsのSELECTポリシーは"admins can select..."という
+-- 名前だがrole='admin'条件が無く、実際はadmin/staffどちらも閲覧できる。
+--
+-- staff/page.tsx が自分の評価期間を切り替えて過去データを見るために
+-- staff自身のセッションでevaluation_periods(id, name)を直接SELECTしており、
+-- これは正規の機能。role='admin'を足すとstaffの評価閲覧機能が壊れるため、
+-- 挙動は変更せず、ポリシー名とコメントを実態(組織メンバー全員がSELECT可、
+-- INSERT/UPDATE/DELETEのみadmin限定)に合わせて修正する。
+
+DROP POLICY IF EXISTS "admins can select evaluation_periods" ON evaluation_periods;
+
+-- 同じorganization_idの組織メンバー(admin/staff問わず)は閲覧可能
+CREATE POLICY "organization members can select evaluation_periods"
+ON evaluation_periods FOR select
+TO authenticated
+USING (
+  organization_id = (
+    SELECT organization_id FROM profiles
+    WHERE id = auth.uid()
+  )
+);


### PR DESCRIPTION
## 概要

Closes #223

`evaluation_periods`のSELECTポリシーが`"admins can select evaluation_periods"`という名前にもかかわらず`role = 'admin'`条件を持たず、staffもSELECTできる状態だった。同ファイルのINSERT/UPDATE/DELETEポリシーは全て`role = 'admin'`を要求しているため、SELECTだけ命名と実態が食い違っていた。

## #217/#219/#222との違い

これらは実際にstaffが読めてはいけないデータが読めてしまう脆弱性だったが、今回は事情が異なる。`src/app/(protected)/staff/page.tsx`がstaff自身のセッションクライアントで`evaluation_periods`(id, name)を直接取得し、評価期間セレクター経由でstaffが自分の過去の評価データを切り替えて閲覧する機能に使っている。これは正規の要件であり、issueの提案通り機械的に`role = 'admin'`を追加すると**staffの評価閲覧機能が壊れる**。

## 対応

挙動(role条件)は変更せず、ポリシー名を`"organization members can select evaluation_periods"`に変更し、「SELECTは組織メンバー全員に意図的に許可、INSERT/UPDATE/DELETEのみadmin限定」という設計意図をコメントで明記した。`id`/`name`/`is_current`は個人情報を含まない低機微情報であり、staffが同一組織の評価期間一覧を見ること自体に実害はない。

## Test plan

- [x] ローカルSupabaseにmigration適用、ポリシー名・USING句を確認
- [x] SQLでstaffが引き続き自組織の`evaluation_periods`をSELECTできることを確認(既存機能への回帰無し)
- [x] `npm run check`(lint + typecheck)
- [x] `npm run test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)