### PR TITLE
fix: evaluations系のSELECT RLSがroleチェックを欠いておりstaffが他スタッフの評価を閲覧できた問題を修正

### DIFF
--- a/supabase/migrations/20260729082516_restrict_evaluations_select_staff_scope.sql
+++ b/supabase/migrations/20260729082516_restrict_evaluations_select_staff_scope.sql
@@ -1,0 +1,68 @@
+-- #216 対応: evaluations/evaluation_sections/evaluation_itemsのSELECTポリシーに
+-- role='admin'条件が無く、staffが同じ組織の他スタッフ全員の評価データ
+-- (評価コメント・スコア等)を閲覧できてしまう問題を修正する。
+--
+-- #223(evaluation_periods)とは異なり、staffが見て良いのは自分自身の評価
+-- だけであり、他スタッフの評価が見えること自体がプライバシー上の問題。
+-- そのため単純にadmin限定にするのではなく、
+-- 「adminは組織内全件、staffは自分自身の評価のみ」という条件に修正する。
+
+-- evaluations: staff_idを直接持つため staff_id = auth.uid() で判定できる
+DROP POLICY IF EXISTS "admins can select evaluations" ON evaluations;
+
+CREATE POLICY "organization members can select evaluations"
+ON evaluations FOR SELECT
+TO authenticated
+USING (
+  organization_id = (
+    SELECT organization_id FROM profiles
+    WHERE id = auth.uid()
+  )
+  AND (
+    staff_id = auth.uid()
+    OR (SELECT role FROM profiles WHERE id = auth.uid()) = 'admin'
+  )
+);
+
+-- evaluation_sections: staff_idを持たないため、evaluationsを辿って判定する
+DROP POLICY IF EXISTS "admins can select evaluation_sections" ON evaluation_sections;
+
+CREATE POLICY "organization members can select evaluation_sections"
+ON evaluation_sections FOR SELECT
+TO authenticated
+USING (
+  organization_id = (
+    SELECT organization_id FROM profiles
+    WHERE id = auth.uid()
+  )
+  AND (
+    (SELECT role FROM profiles WHERE id = auth.uid()) = 'admin'
+    OR EXISTS (
+      SELECT 1 FROM evaluations
+      WHERE evaluations.id = evaluation_sections.evaluation_id
+      AND evaluations.staff_id = auth.uid()
+    )
+  )
+);
+
+-- evaluation_items: evaluation_sections->evaluationsと2段階辿って判定する
+DROP POLICY IF EXISTS "admins can select evaluation_items" ON evaluation_items;
+
+CREATE POLICY "organization members can select evaluation_items"
+ON evaluation_items FOR SELECT
+TO authenticated
+USING (
+  organization_id = (
+    SELECT organization_id FROM profiles
+    WHERE id = auth.uid()
+  )
+  AND (
+    (SELECT role FROM profiles WHERE id = auth.uid()) = 'admin'
+    OR EXISTS (
+      SELECT 1 FROM evaluation_sections
+      JOIN evaluations ON evaluations.id = evaluation_sections.evaluation_id
+      WHERE evaluation_sections.id = evaluation_items.evaluation_section_id
+      AND evaluations.staff_id = auth.uid()
+    )
+  )
+);


### PR DESCRIPTION
## 概要

Closes #216

`evaluations` / `evaluation_sections` / `evaluation_items` のSELECTポリシーが`"admins can select ~"`という名前にもかかわらず`role = 'admin'`条件を持たず、`organization_id`が一致するだけでstaffが同じ組織の**他スタッフ全員の評価データ**(評価コメント・スコア等)を閲覧できる問題を修正する。

## 影響

アプリのUI(`staff/page.tsx`)は`.eq('staff_id', user.id)`で自分の評価に絞り込んでいるが、これはアプリ層の制御でありDBレベルの防御にはならない。Supabase JSクライアント(anon key + staffのJWT)を直接叩けば、この絞り込みを回避して同僚の人事評価情報(`total_comment`/`action_plan`/`future_vision`やスコア・コメント)を全件取得できる。

## #223(evaluation_periods)との違い

#223は「staffが組織の情報を見ること自体は正規の要件」だったが、今回はstaffが見て良いのは自分自身の評価のみであるべきで、他スタッフの評価が見えること自体がプライバシー上の問題。そのため単純にadmin限定にするのではなく、「adminは組織内全件、staffは自分自身の評価のみ」という条件に修正した。

## 対応

- `evaluations`: `staff_id`を直接持つため`staff_id = auth.uid()`で判定
- `evaluation_sections`: `staff_id`を持たないため、`evaluations`を`EXISTS`で辿って判定
- `evaluation_items`: `evaluation_sections`→`evaluations`と2段階`EXISTS`で辿って判定

いずれも`organization_id`一致 AND (`role = 'admin'` OR 自分自身の評価)という条件に統一。

## Test plan

- [x] ローカルSupabaseにmigration適用
- [x] SQLで攻撃再現: staffが`select('*')`しても自分の評価しか返らないことを確認(他staffのevaluations/sections/itemsは0件)
- [x] SQLで正常系確認: staffは自分自身のevaluation_sections/itemsを引き続き閲覧できることを確認(既存機能への回帰無し)
- [x] SQLで正常系確認: adminは組織内全件を閲覧できることを確認
- [x] `npm run check`(lint + typecheck)
- [x] `npm run test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)