### PR TITLE
fix: upsertEvaluationsがperiodIdの所属組織を検証していない問題を修正

### DIFF
--- a/src/app/(protected)/admin/staff/[staffId]/evaluation/actions.ts
+++ b/src/app/(protected)/admin/staff/[staffId]/evaluation/actions.ts
@@ -59,6 +59,15 @@ const upsertEvaluations = async (
 
   if (staffError || !staff) throw new Error('スタッフが見つかりません');
 
+  const { data: period, error: periodError } = await supabase
+    .from('evaluation_periods')
+    .select('id')
+    .eq('id', periodId)
+    .eq('organization_id', orgId)
+    .single();
+
+  if (periodError || !period) throw new Error('評価期間が見つかりません');
+
   const validated = evaluationSchema.safeParse(data);
   if (!validated.success) throw new Error('入力内容を確認してください');
 


### PR DESCRIPTION
## Summary
- `upsertEvaluations` は `staffId` の組織所属チェックはあったが、`periodId` (`evaluation_period_id`) には同様のチェックがなく、他組織の評価期間IDを指定して評価を作成できてしまっていた
- `editStaff` 等と同じパターンで、upsert前に `periodId` が呼び出し管理者の `orgId` に属する `evaluation_periods` かを確認する処理を追加

Closes #220 (#208と同根の問題)

## Test plan
- [x] `npm run check` (lint + typecheck) — 既存の無関係な警告1件のみ、エラーなし
- [x] `npm run test` — 21件全てパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)