### PR TITLE
fix: service_roleにpublicスキーマのテーブルGRANTを追加

### DIFF
--- a/supabase/migrations/20260730054457_grant_dml_privileges_service_role.sql
+++ b/supabase/migrations/20260730054457_grant_dml_privileges_service_role.sql
@@ -1,0 +1,14 @@
+-- #212 対応: 20260624053110_grant_dml_privileges.sqlでauthenticatedロールへの
+-- テーブルGRANTを追加した際、service_roleへのGRANTが漏れていた。
+--
+-- service_roleはBYPASSRLS属性によりRLSチェックはスキップされるが、
+-- テーブルレベルのGRANTはRLSとは独立した権限レイヤーであり免除されない。
+-- そのためservice_roleクライアント経由のテーブル直接操作
+-- (src/lib/utils/upload.tsのuploadStaffAvatar、
+--  src/app/(protected)/admin/staff/actions.tsのaddStaff)が
+-- permission deniedで失敗する状態だった。
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO service_role;
+
+-- 今後追加されるテーブルにも自動付与（再発防止）
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO service_role;


### PR DESCRIPTION
## Summary
- `20260624053110_grant_dml_privileges.sql` で `authenticated` ロールへのテーブルGRANT(SELECT/INSERT/UPDATE/DELETE)を追加した際、`service_role` へのGRANTが漏れていた
- `service_role` は `BYPASSRLS` 属性でRLSチェックはスキップされるが、テーブルレベルのGRANTはRLSと独立した権限レイヤーであり免除されない。ローカルDBで実際に `service_role=Dxtm`(TRUNCATE/REFERENCES/TRIGGER/MAINTAINのみ)であることを確認した
- 同じ内容のGRANTを `service_role` にも追加するマイグレーションを新規追加

## 影響範囲(issue本文より広い可能性)
issue #212本文では影響箇所を `uploadStaffAvatar`(`src/lib/utils/upload.ts`)のみとしているが、`addStaff`(`src/app/(protected)/admin/staff/actions.ts`)も同じく `supabaseAdmin.from('profiles').update(...)` を使っており、2026-06-24以降は同様に失敗していた可能性が高い。`20260728084115_restrict_profiles_role_org_columns.sql` のコメントで「role/organization_idを書き込む唯一の正規フローはaddStaff()で、service_roleクライアント経由のためこの制限の影響を受けない」としているが、その前提自体が本issueのGRANT漏れで崩れていた。今回の修正でどちらも解消される。

Closes #212

## Test plan
- [x] マイグレーション適用後、ローカルDBで `service_role` が `profiles`/`evaluations` 等に `arwd`(SELECT/INSERT/UPDATE/DELETE)を持つことを `\dp` で確認
- [x] `npm run db:types` — 型定義への影響なし(GRANTはスキーマ変更ではないため想定通り)
- [x] `npm run check` (lint + typecheck) — 既存の無関係な警告1件のみ、エラーなし
- [x] `npm run test` — 21件全てパス
- [ ] 本番Supabaseプロジェクト側の `service_role` GRANT状況も別途確認要(issue本文にも記載あり)

🤖 Generated with [Claude Code](https://claude.com/claude-code)