### PR TITLE
refactor: staffId/periodIdの組織所属チェックをrequireRowInOrgに共通化

### DIFF
--- a/src/app/(protected)/admin/staff/[staffId]/evaluation/actions.ts
+++ b/src/app/(protected)/admin/staff/[staffId]/evaluation/actions.ts
@@ -2,6 +2,7 @@
 
 import { createClient } from '@/lib/supabase/server';
 import { requireAdmin } from '@/lib/utils/requireAdmin';
+import { requireRowInOrg } from '@/lib/utils/requireRowInOrg';
 import {
   EvaluationInput,
   evaluationSchema,
@@ -50,23 +51,21 @@ const upsertEvaluations = async (
 
   const { orgId, user } = await requireAdmin(supabase);
 
-  const { data: staff, error: staffError } = await supabase
-    .from('profiles')
-    .select('id')
-    .eq('id', staffId)
-    .eq('organization_id', orgId)
-    .single();
+  await requireRowInOrg(
+    supabase,
+    'profiles',
+    staffId,
+    orgId,
+    'スタッフが見つかりません'
+  );
 
-  if (staffError || !staff) throw new Error('スタッフが見つかりません');
-
-  const { data: period, error: periodError } = await supabase
-    .from('evaluation_periods')
-    .select('id')
-    .eq('id', periodId)
-    .eq('organization_id', orgId)
-    .single();
-
-  if (periodError || !period) throw new Error('評価期間が見つかりません');
+  await requireRowInOrg(
+    supabase,
+    'evaluation_periods',
+    periodId,
+    orgId,
+    '評価期間が見つかりません'
+  );
 
   const validated = evaluationSchema.safeParse(data);
   if (!validated.success) throw new Error('入力内容を確認してください');

--- a/src/app/(protected)/admin/staff/actions.ts
+++ b/src/app/(protected)/admin/staff/actions.ts
@@ -3,6 +3,7 @@
 import { createAdminClient } from '@/lib/supabase/admin';
 import { createClient } from '@/lib/supabase/server';
 import { requireAdmin } from '@/lib/utils/requireAdmin';
+import { requireRowInOrg } from '@/lib/utils/requireRowInOrg';
 import {
   AddStaffInput,
   addStaffSchema,
@@ -60,14 +61,13 @@ export async function deleteStaff(staffId: string) {
 
   const { orgId } = await requireAdmin(supabase);
 
-  const { data: staff, error: staffError } = await supabase
-    .from('profiles')
-    .select('id')
-    .eq('id', staffId)
-    .eq('organization_id', orgId)
-    .single();
-
-  if (staffError || !staff) throw new Error('スタッフが見つかりません');
+  await requireRowInOrg(
+    supabase,
+    'profiles',
+    staffId,
+    orgId,
+    'スタッフが見つかりません'
+  );
 
   const { error } = await supabaseAdmin.auth.admin.deleteUser(staffId);
   if (error) throw new Error('スタッフの削除に失敗しました');
@@ -81,14 +81,13 @@ export async function editStaff(data: EditStaffInput, staffId: string) {
 
   const { orgId } = await requireAdmin(supabase);
 
-  const { data: staff, error: staffError } = await supabase
-    .from('profiles')
-    .select('id')
-    .eq('id', staffId)
-    .eq('organization_id', orgId)
-    .single();
-
-  if (staffError || !staff) throw new Error('スタッフが見つかりません');
+  await requireRowInOrg(
+    supabase,
+    'profiles',
+    staffId,
+    orgId,
+    'スタッフが見つかりません'
+  );
 
   const validated = editStaffSchema.safeParse(data);
   if (!validated.success) throw new Error('入力内容を確認してください');
@@ -122,14 +121,13 @@ export async function editStaffPassword(
 
   const { orgId } = await requireAdmin(supabase);
 
-  const { data: staff, error: staffError } = await supabase
-    .from('profiles')
-    .select('id')
-    .eq('id', staffId)
-    .eq('organization_id', orgId)
-    .single();
-
-  if (staffError || !staff) throw new Error('スタッフが見つかりません');
+  await requireRowInOrg(
+    supabase,
+    'profiles',
+    staffId,
+    orgId,
+    'スタッフが見つかりません'
+  );
 
   const validated = editStaffPasswordSchema.safeParse(data);
   if (!validated.success) throw new Error('入力内容を確認してください');

--- a/src/lib/utils/requireRowInOrg.ts
+++ b/src/lib/utils/requireRowInOrg.ts
@@ -1,0 +1,19 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+import { Database } from '../../../types/supabase';
+
+export async function requireRowInOrg(
+  supabase: SupabaseClient<Database>,
+  table: 'profiles' | 'evaluation_periods',
+  id: string,
+  orgId: string,
+  errorMessage: string
+) {
+  const { data, error } = await supabase
+    .from(table)
+    .select('id')
+    .eq('id', id)
+    .eq('organization_id', orgId)
+    .single();
+
+  if (error || !data) throw new Error(errorMessage);
+}

--- a/src/lib/utils/upload.ts
+++ b/src/lib/utils/upload.ts
@@ -3,6 +3,7 @@
 import { createAdminClient } from '../supabase/admin';
 import { createClient } from '../supabase/server';
 import { requireAdmin } from './requireAdmin';
+import { requireRowInOrg } from './requireRowInOrg';
 import { AVATAR_ALLOWED_TYPES, AVATAR_MAX_SIZE } from '@/lib/constants/upload';
 
 export async function uploadStaffAvatar(formData: FormData, staffId: string) {
@@ -11,14 +12,13 @@ export async function uploadStaffAvatar(formData: FormData, staffId: string) {
 
   const { orgId } = await requireAdmin(supabase);
 
-  const { data: staff, error: staffError } = await supabase
-    .from('profiles')
-    .select('id')
-    .eq('id', staffId)
-    .eq('organization_id', orgId)
-    .single();
-
-  if (staffError || !staff) throw new Error('スタッフが見つかりません');
+  await requireRowInOrg(
+    supabase,
+    'profiles',
+    staffId,
+    orgId,
+    'スタッフが見つかりません'
+  );
 
   const file = formData.get('avatar');
   if (!(file instanceof File)) throw new Error('ファイルが選択されていません');


### PR DESCRIPTION
## Summary
- `profiles` / `evaluation_periods` の各所で重複していた「id が呼び出し元の organization_id に属するか」の確認処理を `src/lib/utils/requireRowInOrg.ts` に共通化
- 対象箇所 (計6箇所):
  - `src/app/(protected)/admin/staff/actions.ts`: `deleteStaff` / `editStaff` / `editStaffPassword`
  - `src/lib/utils/upload.ts`: `uploadStaffAvatar`
  - `src/app/(protected)/admin/staff/[staffId]/evaluation/actions.ts`: `upsertEvaluations` 内の `profiles` チェックと `evaluation_periods` チェック
- issue本文は `staffId` 専用の `requireStaffInOrg` を提案していたが、`evaluation_periods` (periodId) にも構造が完全一致するチェックがあったため、テーブル名を引数に取る汎用ヘルパー `requireRowInOrg(supabase, table, id, orgId, errorMessage)` として実装。`table` は `'profiles' | 'evaluation_periods'` のユニオン型に絞り、Supabaseの型推論と安全性を維持

Closes #215

## Test plan
- [x] `npm run check` (lint + typecheck) がパスすることを確認
- [x] `npm run test` (Vitest) が全件パスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)