### PR TITLE
fix: staff評価閲覧のstatus絞り込み漏れを修正 (#221)

### DIFF
--- a/src/app/(protected)/staff/page.tsx
+++ b/src/app/(protected)/staff/page.tsx
@@ -115,6 +115,11 @@ export default async function StaffPage({
           <Icons.CircleAlert />
           まだ評価が登録されていません
         </p>
+      ) : targetEvaluation.status === 'draft' ? (
+        <p className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Icons.CircleAlert />
+          下書き中のため表示できません
+        </p>
       ) : (
         <StaffEvaluationSection
           selectedPeriod={selectedPeriod}

--- a/src/app/(protected)/staff/page.tsx
+++ b/src/app/(protected)/staff/page.tsx
@@ -86,6 +86,7 @@ export default async function StaffPage({
     )
     .eq('organization_id', orgId)
     .eq('evaluations.staff_id', user.id)
+    .eq('evaluations.status', 'completed')
     .order('created_at', { ascending: true })
     .limit(4)) as { data: PeriodForChart[] | null; error: unknown };
 


### PR DESCRIPTION
## Summary
- staff自身の評価詳細取得クエリに下書き(`draft`)判定を追加し、admin側(`staff/[staffId]/page.tsx`)と同様に「下書き中のため表示できません」を表示するようにした
- staffのトレンドチャート用クエリに `.eq('evaluations.status', 'completed')` を追加し、下書きのスコアが推移グラフの集計に混ざらないようにした

Closes #221

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test`
- [ ] ローカルでstaffが下書き評価を閲覧できないことを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)